### PR TITLE
Flutter-me feature

### DIFF
--- a/assets/flutter-me/package.json
+++ b/assets/flutter-me/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "flutter-me",
+  "version": "0.0.1",
+  "description": "coming soon",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/cmd/flutterMe.go
+++ b/cmd/flutterMe.go
@@ -60,6 +60,15 @@ var flutterMeCmd = &cobra.Command{
 			fmt.Print(err)
 			fmt.Print("Could not open visual studio code")
 		}
+
+		if _, err := runCmd(".", "code", "--install-extension", "dart-code.dart-code"); err != nil {
+			fmt.Print(err)
+		}
+
+		if _, err := runCmd(".", "code", "--install-extension", "dart-code.flutter"); err != nil {
+			fmt.Print(err)
+		}
+
 	},
 }
 

--- a/cmd/flutterMe.go
+++ b/cmd/flutterMe.go
@@ -1,0 +1,91 @@
+// Copyright © 2019 NAME HERE <EMAIL ADDRESS>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"os/exec"
+	"path"
+	"strings"
+
+	"github.com/leoafarias/fvm/lib/fluttertools"
+
+	"github.com/leoafarias/fvm/lib"
+
+	"github.com/spf13/cobra"
+)
+
+// flutterMeCmd represents the flutterMe command
+var flutterMeCmd = &cobra.Command{
+	Use:   "flutter-me",
+	Short: "Just sets flutter up for you",
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := lib.AddVersion("stable"); err != nil {
+			fmt.Print("There was an issue setting up Flutter")
+		}
+
+		flutterHome := fluttertools.GetFlutterHome()
+		flutterGalleryPath := path.Join(flutterHome, "examples", "flutter_gallery")
+
+		fmt.Println(flutterGalleryPath)
+
+		if _, err := runCmd(".", "open", "-a", "Simulator"); err != nil {
+			fmt.Print(err)
+			fmt.Print("Could not start simulator")
+		}
+
+		if _, err := runCmd(flutterGalleryPath, "flutter", "packages", "get"); err != nil {
+			fmt.Print(err)
+			fmt.Print("Could not get packages")
+		}
+
+		if _, err := runCmd(flutterGalleryPath, "flutter", "run"); err != nil {
+			fmt.Print(err)
+			fmt.Print("Could not run Flutter app")
+		}
+
+		if _, err := runCmd(flutterGalleryPath, "code", "."); err != nil {
+			fmt.Print(err)
+			fmt.Print("Could not open visual studio code")
+		}
+	},
+}
+
+func runCmd(execPath string, key string, args ...string) (string, error) {
+	cmd := exec.Command(key, args...)
+	cmd.Dir = execPath
+
+	o, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSuffix(string(o), "\n"), nil
+
+}
+
+func init() {
+	rootCmd.AddCommand(flutterMeCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// flutterMeCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// flutterMeCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/lib/fluttertools/fluttertools.go
+++ b/lib/fluttertools/fluttertools.go
@@ -112,10 +112,11 @@ func GetFlutterHome() string {
 
 		// Always clean up symlink before
 		os.RemoveAll(usrBinFlutter)
+		// os.MkdirAll(usrBinFlutter, os.ModePerm)
 
 		// Creates a symlink from the usr/local/bin to the flutter exec in the flutterHome
 		if err := os.Symlink(flutterExec, usrBinFlutter); err != nil {
-			// fmt.Println(err)
+			fmt.Println(err)
 			fmt.Println("Please set your flutter path before using the tool")
 			os.Exit(0)
 		}


### PR DESCRIPTION
This is an idea to improve the process of on-boarding or experimentation from javascript developers. The flow could look something like this
`npm install -g flutter-me`

- [x] 1. Download correct fvm binary and install
- [x] 2. Clone flutter repository
- [x] 3. Run flutter setup
- [x] 4. Sets flutter command correctly
- [x] 5. Goes into examples/hello_world 
- [x] 6. Runs flutter packages get
- [x] 7. Opens the simulator
- [x] 8. flutter run on hello world app
- [x] 9. Installs Flutter vscode extension
- [x] 10. installs Dart vscode extension
- [x] 11. opens vscode

Clean up and improvements

- [ ] Wait for simulator to open before running app
- [ ] Better feedback and messaging about what is going on
- [ ] Display flutter doctor output for next steps
- [ ] Allow user to select which project he wants to try
- [ ] Check if vscode is installed

I believe this could be an interesting approach to quickly getting someone to play or experiment with flutter and dart.