### PR TITLE
Fix a error for projectFlutterLink.

### DIFF
--- a/lib/utils/helpers.dart
+++ b/lib/utils/helpers.dart
@@ -56,7 +56,7 @@ Link projectFlutterLink() {
       return link;
     }
     dir = dir.parent;
-    if (rootPrefix == dir.path) {
+    if (rootPrefix(link.path) == dir.path) {
       return null;
     }
   }


### PR DESCRIPTION
The judgment condition of the root directory is wrong.