### PR TITLE
Added debug and release flags for the flutter command

### DIFF
--- a/lib/commands/flutter.dart
+++ b/lib/commands/flutter.dart
@@ -23,7 +23,10 @@ class FlutterCommand extends Command {
           help: '''Suppress analytics reporting when this command runs.''')
       ..addFlag('bug-report',
           help:
-              '''Captures a bug report file to submit to the Flutter team. Contains local paths, device identifiers, and log snippets.''');
+              '''Captures a bug report file to submit to the Flutter team. Contains local paths, device identifiers, and log snippets.''')
+      ..addFlag('debug', help: '''Build a debug version of your app.''')
+      ..addFlag('release',
+          help: '''Build a release version of your app (default mode).''');
   }
 
   Future<void> run() async {

--- a/lib/commands/flutter.dart
+++ b/lib/commands/flutter.dart
@@ -17,16 +17,25 @@ class FlutterCommand extends Command {
     argParser
       ..addOption('device-id',
           abbr: 'd', help: '''Target device id or name (prefixes allowed).''')
-      ..addFlag('version',
+      ..addOption('build-number',
+          help: '''An identifier used as an internal version number.
+          Each build must have a unique identifier to differentiate it from previous builds.
+          It is used to determine whether one build is more recent than another, with higher numbers indicating more recent build.
+          On Android it is used as 'versionCode'.
+          On Xcode builds it is used as 'CFBundleVersion' ''')
+      ..addFlag('version', negatable: false,
           help: '''Reports the version of this tool, on the local version.''')
       ..addFlag('suppress-analytics',
           help: '''Suppress analytics reporting when this command runs.''')
-      ..addFlag('bug-report',
+      ..addFlag('bug-report', negatable: false,
           help:
               '''Captures a bug report file to submit to the Flutter team. Contains local paths, device identifiers, and log snippets.''')
       ..addFlag('debug', help: '''Build a debug version of your app.''')
-      ..addFlag('release',
-          help: '''Build a release version of your app (default mode).''');
+      ..addFlag('release', negatable: false,
+          help: '''Build a release version of your app (default mode).''')
+      ..addFlag('codesign',
+          help:
+              '''Codesign the application bundle (only available on device builds).  (defaults to on)''');
   }
 
   Future<void> run() async {


### PR DESCRIPTION
Added `--debug` and `--release` flags in order to get these commands working:

```bash
> fvm flutter build apk --debug
> fvm flutter build apk --release

> fvm flutter build ios --debug
> fvm flutter build ios --release
```