### PR TITLE
fix errors for windows platform

### DIFF
--- a/lib/fvm.dart
+++ b/lib/fvm.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-import 'package:args/command_runner.dart';
 import 'package:fvm/commands/config.dart';
 import 'package:fvm/commands/flutter.dart';
 import 'package:fvm/commands/install.dart';
@@ -8,7 +7,6 @@ import 'package:fvm/commands/remove.dart';
 import 'package:fvm/commands/runner.dart';
 import 'package:fvm/commands/use.dart';
 import 'package:fvm/utils/logger.dart';
-import 'package:cli_util/cli_logging.dart';
 import 'package:fvm/utils/logger.dart' show logger;
 import 'package:io/ansi.dart';
 

--- a/lib/utils/flutter_tools.dart
+++ b/lib/utils/flutter_tools.dart
@@ -196,7 +196,7 @@ Future<List<String>> flutterListInstalledSdks() async {
 
 /// Links Flutter Dir to existsd SDK
 Future<void> linkProjectFlutterDir(String version) async {
-  final versionBin =
-      Directory(path.join(kVersionsDir.path, version, 'bin', 'flutter'));
+  final versionBin = Directory(path.join(kVersionsDir.path, version, 'bin',
+      Platform.isWindows ? 'flutter.bat' : 'flutter'));
   await linkDir(kLocalFlutterLink, versionBin);
 }

--- a/lib/utils/helpers.dart
+++ b/lib/utils/helpers.dart
@@ -40,7 +40,8 @@ Future<void> linkDir(
 Future<bool> isCurrentVersion(String version) async {
   final link = await projectFlutterLink();
   if (link != null) {
-    return Uri.parse(File(await link.target()).parent.parent.path)
+    return Uri.file(File(await link.target()).parent.parent.path,
+                windows: Platform.isWindows)
             .pathSegments
             .last ==
         version;


### PR DESCRIPTION
thanks for nice tools.

when i use fvm in windows, i found some errors.

we should use 'flutter.bat' to execute command and uri is different with mac os.

I have test them in windows and mac, it seems to work fine both.