### PR TITLE
#51 Add Flutter 1.17+ support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,14 @@ test/.test_coverage.dart
 # Link url to flutter version for tests
 fvm
 
-.vscode/launch.json
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# Visual Studio Code related
+.classpath
+.project
+.settings/
+.vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## UNRELEASED
+
+- Added support for new Flutter 1.17.0+ [versioning scheme](https://groups.google.com/forum/#!msg/flutter-announce/b_EcYtyo8Q4/2QSfdp2aBwAJ) -
+The new versioning scheme includes changes to tag names and thus also version names for FVM. When reinstalling Flutter versions <1.17.0, the FVM install-path will change, potentially breaking projects that rely on the install-path.
+The install-path will change from `~/fvm/versions/1.15.17` to `~/fvm/versions/v1.15.17`. Make sure to change this in your IDE configuration.
+
 ## 0.6.7
 
 - Added `version` command to see currently installed `fvm` version

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Flutter Version Management: A simple cli to manage Flutter SDK versions.
 
 This tool allows you to manage multiple channels and releases, and caches these versions locally, so you don't have to wait for a full setup every time you want to switch versions.
 
-Also, it allows you to grab versions by a specific release, i.e. 1.2.0. In case you have projects in different Flutter SDK versions and do not want to upgrade.
+Also, it allows you to grab versions by a specific release, i.e. `v1.2.0` or `1.17.0-dev.3.1`. In case you have projects in different Flutter SDK versions and do not want to upgrade.
 
 ## Usage
 
@@ -39,7 +39,7 @@ FVM gives you the ability to install many Flutter **releases** or **channels**.
 > fvm install <version>
 ```
 
-Version - use `master` to install the Master channel and `1.8.0` to install the release.
+Version - use `master` to install the Master channel and `v1.8.0` or `1.17.0-dev.3.1` to install the release.
 
 ### Use a SDK Version
 

--- a/lib/utils/flutter_tools.dart
+++ b/lib/utils/flutter_tools.dart
@@ -64,9 +64,7 @@ Future<void> checkIfGitExists() async {
 Future<void> flutterVersionClone(String version) async {
   final versionDirectory = Directory(path.join(kVersionsDir.path, version));
 
-  if (!await isValidFlutterVersion(version)) {
-    throw ExceptionNotValidVersion('"$version" is not a valid version');
-  }
+  version = await coerceValidFlutterVersion(version);
 
   // If it's installed correctly just return and use cached
   if (await checkInstalledCorrectly(version)) {
@@ -76,7 +74,7 @@ Future<void> flutterVersionClone(String version) async {
   await versionDirectory.create(recursive: true);
 
   var result = await Process.run(
-      'git', ['clone', '-b', 'v$version', kFlutterRepo, '.'],
+      'git', ['clone', '-b', version, kFlutterRepo, '.'],
       workingDirectory: versionDirectory.path);
 
   if (result.exitCode != 0) {

--- a/lib/utils/helpers.dart
+++ b/lib/utils/helpers.dart
@@ -6,8 +6,15 @@ import 'package:path/path.dart' as path;
 import 'package:fvm/utils/flutter_tools.dart';
 
 /// Returns true if it's a valid Flutter version number
-Future<bool> isValidFlutterVersion(String version) async {
-  return (await flutterListAllSdks()).contains('v$version');
+Future<String> coerceValidFlutterVersion(String version) async {
+  if ((await flutterListAllSdks()).contains(version)) {
+    return version;
+  }
+  final prefixedVersion = 'v$version';
+  if ((await flutterListAllSdks()).contains(prefixedVersion)) {
+    return prefixedVersion;
+  }
+  throw ExceptionNotValidVersion('"$version" is not a valid version');
 }
 
 /// Returns true if it's a valid Flutter channel

--- a/test/utils/helpers_test.dart
+++ b/test/utils/helpers_test.dart
@@ -3,15 +3,23 @@ import 'package:fvm/utils/helpers.dart';
 
 void main() {
   test('Is Valid Flutter Version', () async {
-    final validVersion = await isValidFlutterVersion('1.8.0') &&
-        await isValidFlutterVersion('1.9.6') &&
-        await isValidFlutterVersion('1.10.5') &&
-        await isValidFlutterVersion('1.9.1+hotfix.4');
-    expect(validVersion, true);
+    expect(await coerceValidFlutterVersion('1.8.0'), 'v1.8.0');
+    expect(await coerceValidFlutterVersion('v1.8.0'), 'v1.8.0');
+
+    expect(await coerceValidFlutterVersion('1.9.6'), 'v1.9.6');
+    expect(await coerceValidFlutterVersion('v1.9.6'), 'v1.9.6');
+
+    expect(await coerceValidFlutterVersion('1.10.5'), 'v1.10.5');
+    expect(await coerceValidFlutterVersion('v1.10.5'), 'v1.10.5');
+
+    expect(await coerceValidFlutterVersion('1.9.1+hotfix.4'), 'v1.9.1+hotfix.4');
+    expect(await coerceValidFlutterVersion('v1.9.1+hotfix.4'), 'v1.9.1+hotfix.4');
+
+    expect(await coerceValidFlutterVersion('1.17.0-dev.3.1'), '1.17.0-dev.3.1');
   });
 
   test('Not Valid Flutter Version', () async {
-    final validVersion = await isValidFlutterVersion('1.8.0.2');
-    expect(validVersion, false);
+    expect(coerceValidFlutterVersion('1.8.0.2'), throws);
+    expect(coerceValidFlutterVersion('v1.17.0-dev.3.1'), throws);
   });
 }


### PR DESCRIPTION
Flutter uses a new versioning scheme starting with version 1.17.0. Tags don't have a ' v' prefix anymore.
This commit ensures that versions with and without prefix are handled correctly.