### PR TITLE
Fix _CastError due to some Dart core errors not having a message field

### DIFF
--- a/lib/fvm.dart
+++ b/lib/fvm.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+
 import 'package:fvm/commands/flutter.dart';
 import 'package:fvm/commands/install.dart';
 import 'package:fvm/commands/list.dart';
@@ -27,7 +28,7 @@ Future<void> fvmRunner(List<String> args) async {
     if (exc is String) {
       logger.stdout(exc);
     } else {
-      logger.stderr('⚠️  ${yellow.wrap(exc?.message as String)}');
+      logger.stderr('⚠️  ${yellow.wrap(exc.toString())}');
       if (args.contains('--verbose')) {
         print(st);
         throw exc;


### PR DESCRIPTION
Most `Exception` subtypes have a message but they are not required to have the field. Neither do `Error` subtypes. Most Dart exceptions/errors return their message when calling `toString()`.

See first stacktrace in https://github.com/leoafarias/fvm/issues/106