### PR TITLE
Fix: Null pinnedVersion

### DIFF
--- a/lib/src/commands/flutter_command.dart
+++ b/lib/src/commands/flutter_command.dart
@@ -31,7 +31,7 @@ class FlutterCommand extends Command {
 
     String flutterExec;
 
-    if (project != null) {
+    if (project != null && project.pinnedVersion != null) {
       flutterExec = getFlutterSdkExec(project.pinnedVersion);
       // Make sure that version is installed
       await checkAndInstallVersion(project.pinnedVersion);


### PR DESCRIPTION

This bug is triggered in `fvm flutter` when the project doesn't the folder is flutter project and doesn't have .fvm setup via `fvm use`.

PS: All hail dart null safety 🤣 