### PR TITLE
add depth arg on git clone process

### DIFF
--- a/packages/cli/lib/src/flutter_tools/git_tools.dart
+++ b/packages/cli/lib/src/flutter_tools/git_tools.dart
@@ -39,6 +39,7 @@ Future<void> runGitClone(String version) async {
     '--progress',
     '--single-branch',
     '-b',
+    '--depth 1',
     version,
     kFlutterRepo,
     versionDirectory.path


### PR DESCRIPTION
As seen in issue #213 the clone of repositories in a mild way can result in problems in the installation process and as a suggestion from the author(@tank777) of the issue I decided to send a pull request with the "functionality" in order to solve the problem.