### PR TITLE
Forward global version `flutter` proxy calls to `flutter` executable

### DIFF
--- a/lib/src/commands/config_command.dart
+++ b/lib/src/commands/config_command.dart
@@ -65,9 +65,6 @@ class ConfigCommand extends BaseCommand {
       shouldSave = true;
     }
 
-    final enabled = await FlutterTools.checkAnalyticsEnabled();
-    print(enabled);
-
     // Save
     if (shouldSave) {
       await SettingsService.save(settings);

--- a/lib/src/utils/commands.dart
+++ b/lib/src/utils/commands.dart
@@ -58,14 +58,14 @@ Future<int> dartGlobalCmd(List<String> args) async {
   );
 }
 
-/// Runs dart cmd
+/// Runs flutter from global version
 Future<int> flutterGlobalCmd(List<String> args) async {
   String execPath;
   // Try to get fvm global version
   final cacheVersion = await CacheService.getGlobal();
   // Get exec path for flutter
   if (cacheVersion != null) {
-    execPath = cacheVersion.dartExec;
+    execPath = cacheVersion.flutterExec;
     FvmLogger.info(
       'FVM: Running global configured version "${cacheVersion.name}"',
     );


### PR DESCRIPTION
Having `fvm flutter …` invoke `dart` instead of `flutter` in this specific case only doesn't sound like intended behavior.

Also includes a fix for a build error introduced in 61ae729.