### PR TITLE
Add alpine 3.13 container image

### DIFF
--- a/.docker/alpine/Dockerfile
+++ b/.docker/alpine/Dockerfile
@@ -1,0 +1,40 @@
+FROM alpine:3.13
+
+USER root
+
+ARG FVM_VERSION
+ARG GLIBC_VERSION="2.28-r0"
+
+# Install Required Tools
+RUN apk -U update && apk -U add \
+  bash \
+  ca-certificates \
+  curl \
+  git \
+  make \
+  libstdc++ \
+  libgcc \
+  mesa-dev \
+  unzip \
+  wget \
+  zlib \
+  && wget https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -O /etc/apk/keys/sgerrand.rsa.pub \
+	&& wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk -O /tmp/glibc.apk \
+	&& wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-bin-${GLIBC_VERSION}.apk -O /tmp/glibc-bin.apk \
+	&& apk add /tmp/glibc.apk /tmp/glibc-bin.apk \
+  && rm -rf /tmp/* \
+	&& rm -rf /var/cache/apk/* \
+  && addgroup -g 1000 flutter \
+  && adduser -u 1000 -G flutter -s /bin/bash -D flutter
+
+USER flutter
+
+ARG HOME=/home/flutter
+
+ENV PATH=$HOME/fvm:$HOME/.pub-cache/bin:$HOME/fvm/default/bin:${PATH}
+
+RUN cd $HOME \
+  && wget https://github.com/leoafarias/fvm/releases/download/${FVM_VERSION}/fvm-${FVM_VERSION}-linux-x64.tar.gz \
+  && tar -xf fvm-${FVM_VERSION}-linux-x64.tar.gz \
+  && rm fvm-${FVM_VERSION}-linux-x64.tar.gz \
+  && fvm --version

--- a/.github/workflows/cli_deploy_docker.yml
+++ b/.github/workflows/cli_deploy_docker.yml
@@ -58,8 +58,8 @@ jobs:
           tags: leoafarias/fvm:${{ github.event.release.tag_name }}
           build-args: FVM_VERSION=${{ github.event.release.tag_name }}
 
-      - name: Build and push
-        id: docker_build
+      - name: Build and push Alpine image
+        id: docker_build_alpine
         uses: docker/build-push-action@v2
         with:
           file: ./.docker/alpine/Dockerfile

--- a/.github/workflows/cli_deploy_docker.yml
+++ b/.github/workflows/cli_deploy_docker.yml
@@ -57,3 +57,12 @@ jobs:
           push: true
           tags: leoafarias/fvm:${{ github.event.release.tag_name }}
           build-args: FVM_VERSION=${{ github.event.release.tag_name }}
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          file: ./.docker/alpine/Dockerfile
+          push: true
+          tags: leoafarias/fvm-alpine:${{ github.event.release.tag_name }}
+          build-args: FVM_VERSION=${{ github.event.release.tag_name }}


### PR DESCRIPTION
## Motivation

Fixes #251 As described in the issue, the docker container that uses `google/dart` has many security notices that get flagged by Twistlock and other open source security vulnerability scanners. This can cause problems using the image in enterprise environments. Using alpine allows to use `fvm` without causing problems with Twistlock.

I used [trivy](https://github.com/aquasecurity/trivy) to run analysis on the new alpine image which shows no vulnerabilities. 

<img width="1280" alt="image" src="https://user-images.githubusercontent.com/74687/114723830-faebf900-9d08-11eb-8103-924d82c473ec.png">


## Approach

1. Created a Dockerfile in `./docker/alpine/Dockerfile` directory which installs necessary dependencies on alpine 3:13 and installs `fvm` using binary releases. 
2. Added a GitHub Action workflow to build and push the alpine image under `fvm-alpine` tag

