### PR TITLE
Support specifying git short hashes for use & install

### DIFF
--- a/lib/src/services/flutter_tools.dart
+++ b/lib/src/services/flutter_tools.dart
@@ -129,6 +129,11 @@ class FlutterTools {
       return ValidVersion(version);
     }
 
+    // Check whether it's a git short hash
+    if (checkIsGitShortHash(name)) {
+      return ValidVersion(name);
+    }
+
     // Throws exception if is not in any above condition
     throw FvmUsageException(
       '$name is not a valid Flutter channel or release',

--- a/lib/src/utils/helpers.dart
+++ b/lib/src/utils/helpers.dart
@@ -21,6 +21,12 @@ bool checkIsReleaseChannel(String name) {
   return kFlutterChannels.contains(name) && name != 'master';
 }
 
+/// Checks if [name] is a short hash of a specific framework commit.
+/// This hash is also shown in the `flutter --version` command.
+bool checkIsGitShortHash(String name) {
+  return RegExp('^[a-f0-9]{10}\$').hasMatch(name);
+}
+
 /// Returns a cache [Directory] for a [version]
 Directory versionCacheDir(String version) {
   return Directory(join(ctx.cacheDir.path, version));
@@ -81,20 +87,24 @@ Map<String, String> _updateEnvVariables(
 /// Returns a weight for all versions and channels
 Version assignVersionWeight(String version) {
   /// Assign version number to continue to work with semver
-  switch (version) {
-    case 'master':
-      version = '400.0.0';
-      break;
-    case 'stable':
-      version = '300.0.0';
-      break;
-    case 'beta':
-      version = '200.0.0';
-      break;
-    case 'dev':
-      version = '100.0.0';
-      break;
-    default:
+  if (checkIsGitShortHash(version)) {
+    version = '500.0.0';
+  } else {
+    switch (version) {
+      case 'master':
+        version = '400.0.0';
+        break;
+      case 'stable':
+        version = '300.0.0';
+        break;
+      case 'beta':
+        version = '200.0.0';
+        break;
+      case 'dev':
+        version = '100.0.0';
+        break;
+      default:
+    }
   }
 
   if (version.contains('v')) {

--- a/test/test_helpers.dart
+++ b/test/test_helpers.dart
@@ -16,6 +16,7 @@ import 'package:test/test.dart';
 
 String release = '1.17.4';
 const channel = 'beta';
+const gitHash = 'f4c74a6ec3';
 String channelVersion;
 
 Directory getFvmTestDir(String key) {

--- a/test/utils/helpers_test.dart
+++ b/test/utils/helpers_test.dart
@@ -7,6 +7,7 @@ import 'package:fvm/src/utils/helpers.dart';
 import 'package:fvm/src/utils/pubdev.dart';
 import 'package:fvm/src/version.dart';
 import 'package:path/path.dart';
+import 'package:pub_semver/pub_semver.dart';
 import 'package:pubspec_yaml/pubspec_yaml.dart';
 import 'package:test/test.dart';
 
@@ -30,6 +31,8 @@ void main() {
     expect(await _inferVersionString('v1.9.1+hotfix.4'), 'v1.9.1+hotfix.4');
 
     expect(await _inferVersionString('1.17.0-dev.3.1'), '1.17.0-dev.3.1');
+
+    expect(await _inferVersionString('f4c74a6ec3'), 'f4c74a6ec3');
   });
 
   test('Not Valid Flutter Version', () async {
@@ -63,5 +66,13 @@ void main() {
     // expect(newEnvVar[envName], envVars[envName]);
     expect(newEnvVar[envName].contains(fakePath), true);
     expect(envVars, isNot(newEnvVar));
+  });
+
+  test('Assigns version weights', () async {
+    expect(Version.parse('500.0.0'), assignVersionWeight('0941968447'));
+    expect(Version.parse('400.0.0'), assignVersionWeight('master'));
+    expect(Version.parse('300.0.0'), assignVersionWeight('stable'));
+    expect(Version.parse('200.0.0'), assignVersionWeight('beta'));
+    expect(Version.parse('100.0.0'), assignVersionWeight('dev'));
   });
 }


### PR DESCRIPTION
Let's users install & bind to a specific framework revision.

The test in `test/commands_test.dart` has not yet been updated.