### PR TITLE
ci: use `dart pub` instead of `pub` standalone, because it's deprecated

### DIFF
--- a/.github/workflows/deploy_homebrew.yml
+++ b/.github/workflows/deploy_homebrew.yml
@@ -24,13 +24,13 @@ jobs:
       - uses: actions/checkout@v1
 
       - name: Install dependencies
-        run: pub get
+        run: dart pub get
 
       - name: Build Version Number
-        run: pub run build_runner build --delete-conflicting-outputs
+        run: dart pub run build_runner build --delete-conflicting-outputs
 
       - name: Test
-        run: pub run test
+        run: dart pub run test
 
       - name: Deploy to Homebrew
-        run: pub run grinder pkg-homebrew-update
+        run: dart pub run grinder pkg-homebrew-update

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,10 +32,10 @@ jobs:
           channel: ${{ matrix.sdk-version }}
 
       - name: Install dependencies
-        run: pub get
+        run: dart pub get
 
       - name: Run Test and Builder
-        run: pub run build_runner test --delete-conflicting-outputs
+        run: dart pub run build_runner test --delete-conflicting-outputs
 
   release:
     name: Release
@@ -52,13 +52,13 @@ jobs:
           fetch-depth: 0
 
       - name: Install dependencies
-        run: pub get
+        run: dart pub get
 
       - name: Build Version Number
-        run: pub run build_runner build --delete-conflicting-outputs
+        run: dart pub run build_runner build --delete-conflicting-outputs
 
       - name: Deploy Github
-        run: pub run grinder pkg-github-all
+        run: dart pub run grinder pkg-github-all
 
       - name: Deploy to Pub
-        run: pub run grinder pkg-pub-deploy
+        run: dart pub run grinder pkg-pub-deploy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
       #     channel: ${{ matrix.sdk-version }}
 
       - name: Install dependencies
-        run: pub get
+        run: dart pub get
 
       - name: Run Test and Builder
-        run: pub run build_runner test --delete-conflicting-outputs
+        run: dart pub run build_runner test --delete-conflicting-outputs


### PR DESCRIPTION
`pub` standalone is deprecated and should be replaced with `dart pub`.