### PR TITLE
reduce download and storage size

### DIFF
--- a/lib/src/services/git_tools.dart
+++ b/lib/src/services/git_tools.dart
@@ -45,6 +45,8 @@ class GitTools {
       if (!version.isGitHash) ...[
         '-c',
         'advice.detachedHead=false',
+        '--depth=1',
+        '--no-single-branch',
         '-b',
         channel ?? version.name,
       ],


### PR DESCRIPTION
 reduce download and storage size of repositories/versions by
limiting the history to 1 but keeping all references (--no-single-branch).