### PR TITLE
Android Studio Integration

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -23,6 +23,9 @@ const kFvmLegacyConfigFileName = 'fvm_config.json';
 /// Vscode name
 const kVsCode = 'VSCode';
 
+/// Android Studio name
+const kAndroidStudio = 'Android Studio';
+
 /// Environment variables
 final _env = Platform.environment;
 

--- a/lib/src/commands/doctor_command.dart
+++ b/lib/src/commands/doctor_command.dart
@@ -122,7 +122,7 @@ class DoctorCommand extends BaseCommand {
       table.insertRow([kVsCode, 'No .vscode directory found']);
     }
 
-    table.insertRow(['Android Studio']);
+    table.insertRow([kAndroidStudio]);
 
     // Get localproperties file within flutter project
     final localPropertiesFile =
@@ -140,8 +140,42 @@ class DoctorCommand extends BaseCommand {
       table.insertRow(['Matches pinned version:', sdkPath == resolvedLink]);
     } else {
       table.insertRow([
-        'Android Studio',
+        kAndroidStudio,
         'No local.properties file found in android directory'
+      ]);
+    }
+
+    final dartSdkFile = File(join(project.path, '.idea', 'libraries', 'Dart_SDK.xml'));
+
+    if (dartSdkFile.existsSync()) {
+      final dartSdk = dartSdkFile.readAsStringSync();
+      final containsUserHome = dartSdk.contains(r'$USER_HOME$');
+      final containsProjectDir = dartSdk.contains(r'$PROJECT_DIR$');
+      final containsSymLinkName = dartSdk.contains('.fvm/flutter_sdk');
+
+      if (!containsUserHome && containsProjectDir) {
+        if (containsSymLinkName) {
+          table.insertRow([
+            'SDK Path',
+            'SDK Path points to project directory. Android Studio will dynamically switch SDK when using "fvm use"'
+          ]);
+        }
+        else {
+          table.insertRow([
+            'SDK Path',
+            'SDK Path points to project directory, but does not use the flutter_sdk symlink. Using "fvm use" will break the project. Please consult documentation.'
+          ]);
+        }
+      } else {
+        table.insertRow([
+          'SDK Path',
+          'SDK Path does not point to the project directory. "fvm use" will not make Android Studio switch Flutter version. Please consult documentation.'
+        ]);
+      }
+    } else {
+      table.insertRow([
+        kAndroidStudio,
+        'No .idea folder found'
       ]);
     }
 

--- a/website/docs/guides/android_studio.md
+++ b/website/docs/guides/android_studio.md
@@ -1,0 +1,72 @@
+---
+id: androidstudio
+title: Android Studio Integration
+sidebar_position: 3
+---
+
+Read this guide to learn how to use fvm with Android Studio.
+
+Please note, that you need to do this per project.
+
+:::info
+Before proceeding, make sure, you've run `fvm use` with a specific version or channel in your project.
+Otherwise you cannot setup the Android Studio integration.
+:::
+
+## Update Android Studio Settings
+
+1. In Android Studio go to `Languages & Frameworks > Flutter` or search for Flutter and change Flutter SDK path.
+2. Copy the **_absolute_** path of fvm symbolic link in your root project directory. Example: `/absolute-project-path/.fvm/flutter_sdk`
+3. Apply the changes.
+
+### Symlink path
+
+Due to `.fvm/flutter_sdk` being a symlink, Android Studio may visually change the value of the path to the absolute path whereever the symlink does point to.
+As long as you leave the path untouched, it should work as expected.
+
+Please run `fvm doctor` in your project and find `Android Studio > SDK Path`. 
+It will show an information, if something has not been setup correctly.
+
+:::important SDK change
+If you're changing the SDK via `fvm use` it may take Android Studio some seconds to notice the change.
+
+If it does not recognize it after some seconds or after a restart, please run `fvm doctor` in your project's directory.
+Find `Android Studio > SDK Path`. 
+It will show an information, if something has not been setup correctly.
+:::
+
+## Ignore Flutter SDK root
+
+If you want to ignore the Flutter SDK root directory within Android Studio you can add the following to `.idea/workspace.xml`.
+
+```xml
+<component name="VcsManagerConfiguration">
+  <ignored-roots>
+    <path value="$PROJECT_DIR$/.fvm/flutter_sdk" />
+  </ignored-roots>
+</component>
+...
+```
+
+If that doesn't work, go to Android Studio -> Preferences -> Editor -> File Types -> Ignored Files and Folders and add `flutter_sdk`:
+![Android Studio Configuration](../../../assets/android-studio-config.png)
+
+## Troubleshooting
+
+### Android Studio is not changing the SDK then using `fvm use`
+
+If you setup Android Studio like described above and it does not change the SDK when using `fvm use`,
+open the file `.idea/libraries/Dart_SDK.xml` in your project's root directory.
+
+Within this file, you should check, if all paths contain `$PROJECT_DIR$/.fvm/flutter_sdk`.
+If so, then the setup should be correct and you may should restart Android Studio.
+
+If it is not the case, the setup was not correct.
+Now, select any other Flutter version you have available. 
+Using one from `fvm` is ok, as long as you point to it directly, not via the `.fvm/flutter_sdk` symlink.
+After selecting any other version, `Apply` the changes in Android Studio.
+After that, select `.fvm/flutter_sdk` again and `Apply` the changes.
+
+Now, everything should work as expected.
+
+If nothing has helped, please see [this issue](https://github.com/leoafarias/fvm/issues/310#issuecomment-1822660953) for more insights.

--- a/website/docs/references/configuration.mdx
+++ b/website/docs/references/configuration.mdx
@@ -103,34 +103,3 @@ Alternatively, you can specify only selected versions. The following snippet wil
 ```
 
 To change current Flutter version open a project and select `Flutter: Change SDK` in the command palette. You should see all the versions as depicted in the following screenshot.
-
-### Android Studio
-
-1. Go to `Languages & Frameworks > Flutter` or search for Flutter and change Flutter SDK path.
-2. Copy the **_absolute_** path of fvm symbolic link in your root project directory. Example: `/absolute-project-path/.fvm/flutter_sdk`
-3. Apply the changes.
-4. Restart Android Studio to see the new settings applied.
-
-:::important
-For Android Studio to detect the dynamic change of SDKs, the installed SDK must have finished setup.
-
-Using `fvm install <VERSION>` will ensure that setup during install.
-
-If you have installed through another command and setup was not completed. You can finish by just running `fvm flutter --version`
-
-Android Studio might take a few seconds to detect the dynamic SDK change.
-:::
-
-If you want to ignore the Flutter SDK root directory within Android Studio you can add the following to `.idea/workspace.xml`.
-
-```xml
-<component name="VcsManagerConfiguration">
-  <ignored-roots>
-    <path value="$PROJECT_DIR$/.fvm/flutter_sdk" />
-  </ignored-roots>
-</component>
-...
-```
-
-If that doesn't work, go to Android Studio -> Preferences -> Editor -> File Types -> Ignored Files and Folders and add `flutter_sdk`:
-![Android Studio Configuration](../../../assets/android-studio-config.png)


### PR DESCRIPTION
Hi @leoafarias 

as per #310, this PR will improve fvm a bit around Android Studio.

* Creates the `flutter_sdk` symlink again which was removed for 3-beta, but available in 2. After some research in #310 it seems that having `flutter_sdk` is the easiest way to work with dynamic SDKs in Android Studio, because Android Studio does not save one path to the SDK, but one path for each module. That seems to make trouble if fvm would start managing all those paths. So its best to leave it to Android Studio itself via the symlink.
* Adds a little check to `fvm doctor` in order to check if `Dart_SDK.xml` contains `$PROJECT_DIR` (correct) or `$USER_HOME$` (incorrect) and will also check, if it points to the `flutter_sdk` symlink.
* In the docs, it looks like that you wanted to create dedicated pages for each IDE. So I've moved everything regarding Android Studio from `configuration.mdx` in a dedicated `android_studio.md` file.
* I also added some more information in the docs

Please let me know, if there's anything else I can do in order to help with the Android Studio integration.