### PR TITLE
feature: allowing FLUTTER_GIT_URL to be the default value of flutterUrl

### DIFF
--- a/lib/src/services/config_repository.dart
+++ b/lib/src/services/config_repository.dart
@@ -5,6 +5,8 @@ import 'package:fvm/src/utils/helpers.dart';
 
 import '../../fvm.dart';
 
+const String flutterGitUrl = 'FLUTTER_GIT_URL';
+
 /// Service to manage FVM Config
 class ConfigRepository {
   const ConfigRepository._();
@@ -47,6 +49,11 @@ class ConfigRepository {
     String? flutterUrl;
     String? cachePath;
     bool? priviledgedAccess;
+
+    // Default to Flutter's environment variable if present; can still be overridden
+    if (environments.containsKey(flutterGitUrl)) {
+      flutterUrl = environments[flutterGitUrl];
+    }
 
     for (final variable in ConfigKeys.values) {
       final value = environments[variable.envKey];


### PR DESCRIPTION
The Flutter project reports a warning to users who replace the standard GitHub location of Flutter with their own. They also provide an environment variable (`FLUTTER_GIT_URL`) which can be set by the user to indicate that this is intentional.

FVM provides a similar feature to override the GIT location from which the Flutter install will be cloned, and it is implemented as the command-line parameter `--flutterUrl`.

Defaulting to using the environment variable defined by Flutter as the value of `flutterUrl`, provides most corporations that host their own repository with a seamless use of the `fvm` tool without requiring all developers to include the `--flutterUrl` parameter manually.