### PR TITLE
Re-enables finding project without a previous FVM config based on pubspec.yaml.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.10
+
+* Re-enables finding project without a previous FVM config based on pubspec.yaml.
+
 ## 3.0.9
 
 * Adds .gitignore even if project is not a git repository. As IDEs and tools use it as a reference for project indexing.

--- a/lib/src/services/project_service.dart
+++ b/lib/src/services/project_service.dart
@@ -42,7 +42,7 @@ class ProjectService extends ContextService {
     if (project.hasConfig) return project;
 
     // if project has a pubspec file return it
-    // if (project.hasPubspec) return project;
+    if (project.hasPubspec) return project;
 
     // Return working directory if has reached root
     if (isRootDir) return Project.loadFromPath(context.workingDirectory);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: fvm
 description: A simple cli to manage Flutter SDK versions per project. Support
   channels, releases, and local cache for fast switching between versions.
-version: 3.0.9
+version: 3.0.10
 homepage: https://github.com/leoafarias/fvm
 
 environment:


### PR DESCRIPTION
A function in the Find Ancestor funciont commented out with a test message. This is probably the cause for empty projects without a FVM configuration not working with the new FVM.

https://github.com/leoafarias/fvm/issues/638