### PR TITLE
Add skipping version mismatch handling when using force or running with a custom fvm version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.12
+
+* Adds skipping version mismatch handling when using force or running with a custom fvm version.
+
 ## 3.0.11
 
 * Removed `fvm update` command. Due to issue with brew and chocolatey install.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.11
+
+* Removed `fvm update` command. Due to issue with brew and chocolatey install.
+
 ## 3.0.10
 
 * Fixed issue when config is found in directory no pubspec.yaml. [#638](https://github.com/leoafarias/fvm/issues/638)

--- a/lib/src/commands/use_command.dart
+++ b/lib/src/commands/use_command.dart
@@ -120,7 +120,7 @@ class UseCommand extends BaseCommand {
       }
     }
 
-    final cacheVersion = await ensureCacheWorkflow(version);
+    final cacheVersion = await ensureCacheWorkflow(version, force: forceOption);
 
     /// Run use workflow
     await useVersionWorkflow(

--- a/lib/src/version.g.dart
+++ b/lib/src/version.g.dart
@@ -1,3 +1,3 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-const packageVersion = '3.0.10';
+const packageVersion = '3.0.11';

--- a/lib/src/workflows/ensure_cache.workflow.dart
+++ b/lib/src/workflows/ensure_cache.workflow.dart
@@ -22,7 +22,7 @@ Future<CacheFlutterVersion> ensureCacheWorkflow(
 }) async {
   _validateContext();
   // Get valid flutter version
-  final validVersion = await validateFlutterVersion(version, force);
+  final validVersion = await validateFlutterVersion(version, force: force);
   try {
     final cacheVersion = CacheService.fromContext.getVersion(validVersion);
 
@@ -39,6 +39,10 @@ Future<CacheFlutterVersion> ensureCacheWorkflow(
 
       if (integrity == CacheIntegrity.versionMismatch && !force && !validVersion.isCustom) {
         return await _handleVersionMismatch(cacheVersion);
+      } else if (force) {
+        logger.warn('Not checking for version mismatch as --force flag is set.');
+      } else if (validVersion.isCustom) {
+        logger.warn('Not checking for version mismatch as custom version is being used.');
       }
 
       // If shouldl install notifiy the user that is already installed
@@ -161,7 +165,7 @@ Future<CacheFlutterVersion> _handleVersionMismatch(
   return ensureCacheWorkflow(version.name, shouldInstall: true);
 }
 
-Future<FlutterVersion> validateFlutterVersion(String version, bool force) async {
+Future<FlutterVersion> validateFlutterVersion(String version, {bool force}) async {
   final flutterVersion = FlutterVersion.parse(version);
 
   if (force) {

--- a/lib/src/workflows/ensure_cache.workflow.dart
+++ b/lib/src/workflows/ensure_cache.workflow.dart
@@ -18,10 +18,11 @@ import '../utils/helpers.dart';
 Future<CacheFlutterVersion> ensureCacheWorkflow(
   String version, {
   bool shouldInstall = false,
+  bool force = false,
 }) async {
   _validateContext();
   // Get valid flutter version
-  final validVersion = await validateFlutterVersion(version);
+  final validVersion = await validateFlutterVersion(version, force);
   try {
     final cacheVersion = CacheService.fromContext.getVersion(validVersion);
 
@@ -36,7 +37,7 @@ Future<CacheFlutterVersion> ensureCacheWorkflow(
         );
       }
 
-      if (integrity == CacheIntegrity.versionMismatch) {
+      if (integrity == CacheIntegrity.versionMismatch && !force && !validVersion.isCustom) {
         return await _handleVersionMismatch(cacheVersion);
       }
 
@@ -160,8 +161,13 @@ Future<CacheFlutterVersion> _handleVersionMismatch(
   return ensureCacheWorkflow(version.name, shouldInstall: true);
 }
 
-Future<FlutterVersion> validateFlutterVersion(String version) async {
+Future<FlutterVersion> validateFlutterVersion(String version, bool force) async {
   final flutterVersion = FlutterVersion.parse(version);
+
+  if (force) {
+    return flutterVersion;
+  }
+
   // If its channel or commit no need for further validation
   if (flutterVersion.isChannel || flutterVersion.isCustom) {
     return flutterVersion;

--- a/lib/src/workflows/ensure_cache.workflow.dart
+++ b/lib/src/workflows/ensure_cache.workflow.dart
@@ -165,7 +165,7 @@ Future<CacheFlutterVersion> _handleVersionMismatch(
   return ensureCacheWorkflow(version.name, shouldInstall: true);
 }
 
-Future<FlutterVersion> validateFlutterVersion(String version, {bool force}) async {
+Future<FlutterVersion> validateFlutterVersion(String version, {bool force = false}) async {
   final flutterVersion = FlutterVersion.parse(version);
 
   if (force) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: fvm
 description: A simple cli to manage Flutter SDK versions per project. Support
   channels, releases, and local cache for fast switching between versions.
-version: 3.0.11
+version: 3.0.12
 homepage: https://github.com/leoafarias/fvm
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: fvm
 description: A simple cli to manage Flutter SDK versions per project. Support
   channels, releases, and local cache for fast switching between versions.
-version: 3.0.10
+version: 3.0.11
 homepage: https://github.com/leoafarias/fvm
 
 environment:


### PR DESCRIPTION
When running fvm use with a custom Flutter version or running with the force command, FVM still tries to correctly handle version mismatching. However, it is expected that the installed version should be used as this is the custom installed folder or is forced by adding the force command.

This should fix issue https://github.com/leoafarias/fvm/issues/653