### PR TITLE
feat: Don't proactively create the legacy `fvm_config.json` file

### DIFF
--- a/lib/src/services/project_service.dart
+++ b/lib/src/services/project_service.dart
@@ -85,11 +85,6 @@ class ProjectService extends ContextService {
     final configFile = project.configPath.file;
     final legacyConfigFile = project.legacyConfigPath.file;
 
-    // If config file does not exists create it
-    if (!configFile.existsSync()) {
-      configFile.createSync(recursive: true);
-    }
-
     final jsonContents = prettyJson(config.toMap());
 
     configFile.write(jsonContents);

--- a/lib/src/services/project_service.dart
+++ b/lib/src/services/project_service.dart
@@ -93,7 +93,9 @@ class ProjectService extends ContextService {
     final jsonContents = prettyJson(config.toMap());
 
     configFile.write(jsonContents);
-    legacyConfigFile.write(prettyJson(config.toLegacyMap()));
+    if (legacyConfigFile.existsSync()) {
+      legacyConfigFile.write(prettyJson(config.toLegacyMap()));
+    }
 
     return Project.loadFromPath(project.path);
   }


### PR DESCRIPTION
I found that when I ran `fvm use stable` the legacy `fvm_config.json` was created.

This PR adds a check for if the legacy config file exists, then it can write to it. If it doesn't, it get skipped.

There was also a redundant check that I removed. Calling `file.write(...)` will already check if the file exists and to create it if it doesn't.