### PR TITLE
feat: add deps flag to optional get project dependencies after switch

### DIFF
--- a/docs/pages/documentation/guides/basic-commands.md
+++ b/docs/pages/documentation/guides/basic-commands.md
@@ -27,6 +27,8 @@ Sets a specific Flutter SDK version for a project, ensuring environment consiste
 
 - `-s,--skip-setup`:  Omits Flutter setup post-installation for expedited process.
 
+- `--skip-pub-get`: Skip resolving dependencies (`flutter pub get`) after switching Flutter SDK.
+
 **Examples**
 
 **Setting a Specific Version**:  

--- a/lib/src/commands/install_command.dart
+++ b/lib/src/commands/install_command.dart
@@ -28,17 +28,17 @@ class InstallCommand extends BaseCommand {
         negatable: false,
       )
       ..addFlag(
-        'deps',
+        'skip-pub-get',
         help: 'Resolves dependencies after switching Flutter SDK',
-        negatable: true,
-        defaultsTo: true,
+        negatable: false,
+        defaultsTo: false,
       );
   }
 
   @override
   Future<int> run() async {
     final setup = boolArg('setup');
-    final resolveDependencies = boolArg('deps');
+    final skipPubGet = boolArg('skip-pub-get');
     String? version;
 
     // If no version was passed as argument check project config.
@@ -65,7 +65,7 @@ class InstallCommand extends BaseCommand {
         project: project,
         force: true,
         skipSetup: !setup,
-        resolveDependencies: resolveDependencies,
+        resolveDependencies: !skipPubGet,
       );
 
       return ExitCode.success.code;

--- a/lib/src/commands/install_command.dart
+++ b/lib/src/commands/install_command.dart
@@ -19,18 +19,26 @@ class InstallCommand extends BaseCommand {
 
   /// Constructor
   InstallCommand() {
-    argParser.addFlag(
-      'setup',
-      abbr: 's',
-      help: 'Builds SDK after install after install',
-      defaultsTo: false,
-      negatable: false,
-    );
+    argParser
+      ..addFlag(
+        'setup',
+        abbr: 's',
+        help: 'Builds SDK after install after install',
+        defaultsTo: false,
+        negatable: false,
+      )
+      ..addFlag(
+        'deps',
+        help: 'Resolves dependencies after switching Flutter SDK',
+        negatable: true,
+        defaultsTo: true,
+      );
   }
 
   @override
   Future<int> run() async {
     final setup = boolArg('setup');
+    final resolveDependencies = boolArg('deps');
     String? version;
 
     // If no version was passed as argument check project config.
@@ -57,6 +65,7 @@ class InstallCommand extends BaseCommand {
         project: project,
         force: true,
         skipSetup: !setup,
+        resolveDependencies: resolveDependencies,
       );
 
       return ExitCode.success.code;

--- a/lib/src/commands/install_command.dart
+++ b/lib/src/commands/install_command.dart
@@ -29,7 +29,7 @@ class InstallCommand extends BaseCommand {
       )
       ..addFlag(
         'skip-pub-get',
-        help: 'Resolves dependencies after switching Flutter SDK',
+        help: 'Skip resolving dependencies after switching Flutter SDK',
         negatable: false,
         defaultsTo: false,
       );

--- a/lib/src/commands/use_command.dart
+++ b/lib/src/commands/use_command.dart
@@ -44,6 +44,12 @@ class UseCommand extends BaseCommand {
         aliases: ['env'],
       )
       ..addFlag(
+        'deps',
+        help: 'Resolves dependencies after switching Flutter SDK',
+        negatable: true,
+        defaultsTo: true,
+      )
+      ..addFlag(
         'skip-setup',
         abbr: 's',
         help: 'Skips Flutter setup after install',
@@ -54,6 +60,7 @@ class UseCommand extends BaseCommand {
   Future<int> run() async {
     final forceOption = boolArg('force');
     final pinOption = boolArg('pin');
+    final resolveDependencies = boolArg('deps');
     final flavorOption = stringArg('flavor');
     final skipSetup = boolArg('skip-setup');
 
@@ -129,6 +136,7 @@ class UseCommand extends BaseCommand {
       force: forceOption,
       skipSetup: skipSetup,
       flavor: flavorOption,
+      resolveDependencies: resolveDependencies,
     );
 
     return ExitCode.success.code;

--- a/lib/src/commands/use_command.dart
+++ b/lib/src/commands/use_command.dart
@@ -45,7 +45,7 @@ class UseCommand extends BaseCommand {
       )
       ..addFlag(
         'skip-pub-get',
-        help: 'Resolves dependencies after switching Flutter SDK',
+        help: 'Skip resolving dependencies after switching Flutter SDK',
         negatable: false,
         defaultsTo: false,
       )

--- a/lib/src/commands/use_command.dart
+++ b/lib/src/commands/use_command.dart
@@ -44,10 +44,10 @@ class UseCommand extends BaseCommand {
         aliases: ['env'],
       )
       ..addFlag(
-        'deps',
+        'skip-pub-get',
         help: 'Resolves dependencies after switching Flutter SDK',
-        negatable: true,
-        defaultsTo: true,
+        negatable: false,
+        defaultsTo: false,
       )
       ..addFlag(
         'skip-setup',
@@ -60,7 +60,7 @@ class UseCommand extends BaseCommand {
   Future<int> run() async {
     final forceOption = boolArg('force');
     final pinOption = boolArg('pin');
-    final resolveDependencies = boolArg('deps');
+    final skipPubGet = boolArg('skip-pub-get');
     final flavorOption = stringArg('flavor');
     final skipSetup = boolArg('skip-setup');
 
@@ -136,7 +136,7 @@ class UseCommand extends BaseCommand {
       force: forceOption,
       skipSetup: skipSetup,
       flavor: flavorOption,
-      resolveDependencies: resolveDependencies,
+      resolveDependencies: !skipPubGet,
     );
 
     return ExitCode.success.code;

--- a/lib/src/workflows/use_version.workflow.dart
+++ b/lib/src/workflows/use_version.workflow.dart
@@ -27,6 +27,7 @@ Future<void> useVersionWorkflow({
   required Project project,
   bool force = false,
   bool skipSetup = false,
+  bool resolveDependencies = true,
   String? flavor,
 }) async {
   // If project use check that is Flutter project
@@ -61,7 +62,9 @@ Future<void> useVersionWorkflow({
 
   await _checkGitignore(updatedProject, force: force);
 
-  await resolveDependenciesWorkflow(updatedProject, version, force: force);
+  if (resolveDependencies) {
+    await resolveDependenciesWorkflow(updatedProject, version, force: force);
+  }
 
   _updateLocalSdkReference(updatedProject, version);
   _updateCurrentSdkReference(updatedProject, version);


### PR DESCRIPTION
In large projects, getting the dependencies may require more than just a `pub get` in the root dir.

This PR adds an optional flag to get the current project dependencies. The default value is `true` to not disrupt current usage. The flag is negatable to _not_ get the dependencies

## Use

![image](https://github.com/leoafarias/fvm/assets/39742020/0cd672e7-4914-4fd0-815c-e92004677920)

## Install

![image](https://github.com/leoafarias/fvm/assets/39742020/48836677-d72f-49ba-a709-51acd9ae9dda)
