### PR TITLE
feat: add force check before install prompt

### DIFF
--- a/lib/src/workflows/ensure_cache.workflow.dart
+++ b/lib/src/workflows/ensure_cache.workflow.dart
@@ -50,7 +50,7 @@ Future<CacheFlutterVersion> ensureCacheWorkflow(
         );
       }
 
-      // If shouldl install notifiy the user that is already installed
+      // If should install notify the user that is already installed
       if (shouldInstall) {
         logger.success(
           'Flutter SDK: ${cyan.wrap(cacheVersion.printFriendlyName)} is already installed.',
@@ -69,13 +69,15 @@ Future<CacheFlutterVersion> ensureCacheWorkflow(
         'Flutter SDK: ${cyan.wrap(validVersion.printFriendlyName)} is not installed.',
       );
 
-      final shouldInstallConfirmed = logger.confirm(
-        'Would you like to install it now?',
-        defaultValue: true,
-      );
+      if (!force) {
+        final shouldInstallConfirmed = logger.confirm(
+          'Would you like to install it now?',
+          defaultValue: true,
+        );
 
-      if (!shouldInstallConfirmed) {
-        exit(ExitCode.success.code);
+        if (!shouldInstallConfirmed) {
+          exit(ExitCode.success.code);
+        }
       }
     }
 


### PR DESCRIPTION
When installing the flutter version from `fvm use <version|flavor>`, there is a prompt 

This PR adds the missing check before the prompt to force the installation.
Fixes: #579 

# Current

## Without Force
![image](https://github.com/leoafarias/fvm/assets/39742020/7ecf77ee-ed6b-4225-805b-6ac4299c6ee2)

## With Force
![image](https://github.com/leoafarias/fvm/assets/39742020/c3610717-5a38-40cd-a170-63119e62b673)

# With PR Changes

## Without Force
![image](https://github.com/leoafarias/fvm/assets/39742020/54ccaa66-89c9-4570-984d-5879bf5c9acf)

## With force
![image](https://github.com/leoafarias/fvm/assets/39742020/bff77e6b-561b-4544-8841-b3d0c55a6b0d)
