### PR TITLE
refactor: reference version file instead of fvmrc

### DIFF
--- a/lib/src/models/config_model.dart
+++ b/lib/src/models/config_model.dart
@@ -271,7 +271,6 @@ class AppConfig extends Config {
 /// Project config
 class ProjectConfig extends Config {
   /// Flutter SDK version configured
-  String? flutterSdkVersion;
 
   /// Flavors configured
   Map<String, String>? flavors;
@@ -292,7 +291,6 @@ class ProjectConfig extends Config {
     super.gitCachePath,
     super.flutterUrl,
     super.priviledgedAccess,
-    this.flutterSdkVersion,
     this.flavors,
     bool? updateVscodeSettings,
     bool? updateGitIgnore,
@@ -311,7 +309,6 @@ class ProjectConfig extends Config {
       gitCachePath: envConfig.gitCachePath,
       flutterUrl: envConfig.flutterUrl,
       priviledgedAccess: envConfig.priviledgedAccess,
-      flutterSdkVersion: map['flutterSdkVersion'] ?? map['flutter'] as String?,
       flavors: map['flavors'] != null ? Map.from(map['flavors'] as Map) : null,
       updateVscodeSettings: map['updateVscodeSettings'] as bool?,
       updateGitIgnore: map['updateGitIgnore'] as bool?,
@@ -368,7 +365,6 @@ class ProjectConfig extends Config {
       gitCachePath: gitCachePath ?? this.gitCachePath,
       flutterUrl: flutterUrl ?? this.flutterUrl,
       priviledgedAccess: priviledgedAccess ?? this.priviledgedAccess,
-      flutterSdkVersion: flutterSdkVersion ?? this.flutterSdkVersion,
       flavors: mergedFlavors,
       updateVscodeSettings: updateVscodeSettings ?? _updateVscodeSettings,
       updateGitIgnore: updateGitIgnore ?? _updateGitIgnore,
@@ -379,7 +375,6 @@ class ProjectConfig extends Config {
   ProjectConfig merge(ProjectConfig config) {
     return copyWith(
       cachePath: config.cachePath,
-      flutterSdkVersion: config.flutterSdkVersion,
       useGitCache: config.useGitCache,
       updateVscodeSettings: config._updateVscodeSettings,
       updateGitIgnore: config._updateGitIgnore,
@@ -399,7 +394,6 @@ class ProjectConfig extends Config {
 
   Map<String, dynamic> toLegacyMap() {
     return {
-      if (flutterSdkVersion != null) 'flutterSdkVersion': flutterSdkVersion,
       if (flavors != null && flavors!.isNotEmpty) 'flavors': flavors,
     };
   }
@@ -412,7 +406,6 @@ class ProjectConfig extends Config {
   Map<String, dynamic> toMap() {
     return {
       ...super.toMap(),
-      if (flutterSdkVersion != null) 'flutter': flutterSdkVersion,
       if (_updateVscodeSettings != null)
         'updateVscodeSettings': _updateVscodeSettings,
       if (_updateGitIgnore != null) 'updateGitIgnore': _updateGitIgnore,


### PR DESCRIPTION
When working in teams, it is ideal to define the flutter versions that we are currently using and commit them to version control. But the working local version _**should not**_ be checked into version control.

# The problem

Updating the `.fvmrc` file with the current working local version of flutter causes the file to contain modifications and could potentially be committed and pushed.

# The Solution

Instead of modifying the `.fvmrc` file, we could have a separate file, which is not version controlled, that contains the current working version.

There is already a file that exists within the project, `.fvm/version`, that could be used for this functionality.

# Changes

This PR introduces the change to remove the `flutter`/`flutterSdkVersion` from `config_model.dart` effectively removing it from the `.fvmrc` and `.fvm/fvm_config.json` files.

By removing `flutterSdkVersion`  from the `.fvmrc` file, the version will be retrieved from `.fvm/version` instead.