### PR TITLE
docs: remove entry to non existing 'Install Revision' page

### DIFF
--- a/docs/pages/documentation/advanced/_meta.json
+++ b/docs/pages/documentation/advanced/_meta.json
@@ -2,9 +2,6 @@
   "custom-version": {
     "title": "Custom Version"
   },
-  "install-revision": {
-    "title": "Install Revision"
-  },
   "release-multiple-channels": {
     "title": "Release Multiple Channels"
   }


### PR DESCRIPTION
I noticed that `Install Revievision` page cannot be opened on the WebSite and it doesn't seem to exist in the docs, so let's remove it to avoid confusion.

<img width="977" alt="image" src="https://github.com/leoafarias/fvm/assets/8143332/e52459a9-b632-4b38-97e2-a4ecaeeda281">
