### PR TITLE
doc: fix command highlight in configuration

### DIFF
--- a/docs/pages/documentation/getting-started/configuration.mdx
+++ b/docs/pages/documentation/getting-started/configuration.mdx
@@ -12,7 +12,7 @@ Configure FVM and IDEs for better support for different development environments
 
 ## Project
 
-There are two main parts for a project that has FVM configured. The `.fvmrc config file and the `.fvm` directory.
+There are two main parts for a project that has FVM configured. The `.fvmrc` config file and the `.fvm` directory.
 
 ### Config File `.fvmrc`
 


### PR DESCRIPTION
Let's fix the highlighting of `.fvmrc`.

<img width="1167" alt="image" src="https://github.com/leoafarias/fvm/assets/8143332/5f35b553-1dc4-4717-a6b7-e90166bf2963">
