### PR TITLE
docs: fix links in FAQ

### DIFF
--- a/docs/pages/documentation/getting-started/faq.md
+++ b/docs/pages/documentation/getting-started/faq.md
@@ -7,7 +7,7 @@ title: FAQ
 
 ### Upgrade Flutter Channel
 
-As described in our [Principles](../getting_started/overview/#principles) FVM does not override standard Flutter behavior. Therefore to upgrade a channel you will have to use standard `flutter upgrade`. You can find more about it in the [Running Flutter](/docs/guides/running_flutter) section.
+As described in our [Principles](../getting-started/#principles) FVM does not override standard Flutter behavior. Therefore to upgrade a channel you will have to use standard `flutter upgrade`. You can find more about it in the [Running Flutter](../guides/running-flutter) section.
 
 ---
 
@@ -74,10 +74,10 @@ C:\src\flutter\bin
 
 ### Git not found after install on Windows
 
-Some users may be greeted by this error after installing FVM in a project.  
+Some users may be greeted by this error after installing FVM in a project.
 
 ```
-Error: Unable to find git in your PATH. 
+Error: Unable to find git in your PATH.
 ```
 
 This happens because of a security update from git where Git now checks for ownership of the folder trying to ensure that the folder you are using Git in has the same user as the owner as your current user account.
@@ -87,7 +87,7 @@ To fix this, we need to mark our repos as safe using the following command:
 git config --global --add safe.directory '*'
 ```
 
-Restart your terminals and VS Code after running this command. This should fix the issue  
+Restart your terminals and VS Code after running this command. This should fix the issue
 
 If you don’t want to mark all the repos as safe, then you can mark only the flutter repo as safe by passing the flutter path instead of *
 


### PR DESCRIPTION
The links on the screenshot lead to 404 at the moment. The current PR fixes that.

<img width="1163" alt="image" src="https://github.com/leoafarias/fvm/assets/8143332/74cb2cb7-87af-4f0e-8b57-0f4b764607b7">