### PR TITLE
fix: forward configured flavors

### DIFF
--- a/lib/src/workflows/use_version.workflow.dart
+++ b/lib/src/workflows/use_version.workflow.dart
@@ -56,7 +56,10 @@ Future<void> useVersionWorkflow({
 
   final updatedProject = ProjectService.fromContext.update(
     project,
-    flavors: {if (flavor != null) flavor: version.name},
+    flavors: {
+      if (flavor != null) flavor: version.name,
+      ...project.flavors,
+    },
     flutterSdkVersion: version.name,
   );
 


### PR DESCRIPTION
# Problem

Whenever I ran `fvm use` the flavors that I defined were erased.

# Solution

Forward the flavors to `Project.fromContext.update(...)` function.