### PR TITLE
Fix assignVersionWeight do not handle custom version

### DIFF
--- a/lib/src/utils/helpers.dart
+++ b/lib/src/utils/helpers.dart
@@ -62,6 +62,10 @@ String assignVersionWeight(String version) {
     version = version.replaceFirst('v', '');
   }
 
+  if (version.contains('custom_')) {
+    version = version.replaceFirst('custom_', '');
+  }
+
   try {
     // Checking to throw an issue if it cannot parse
     // ignore: avoid-unused-instances


### PR DESCRIPTION
assignVersionWeight function should remove `custom_` before parse version else `fvm dart` will not working because
```
bool get hasOldBinPath {
  return compareSemver(assignVersionWeight(version), '1.17.5') <= 0;
}
```
Fixes https://github.com/leoafarias/fvm/pull/654#issuecomment-2005697264