### PR TITLE
Update Dockerfile due to discontinuation of google/dart image

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/dart:latest
+FROM dart:latest
 
 ARG FVM_VERSION
 
@@ -7,4 +7,4 @@ RUN apt-get install --quiet --yes \
     unzip \
     apt-utils
 
-RUN pub global activate fvm ${FVM_VERSION}
+RUN dart pub global activate fvm ${FVM_VERSION}


### PR DESCRIPTION
We should target the `dart:latest` Docker image, as this is now the official Dart image and (as the title suggests) the previous google/dart image is no longer available.