### PR TITLE
fix(global): adds trailing space to version prompt

### DIFF
--- a/lib/src/utils/console_utils.dart
+++ b/lib/src/utils/console_utils.dart
@@ -32,7 +32,7 @@ String cacheVersionSelector(List<CacheFlutterVersion> versions) {
 
   final versionsList = versions.map((version) => version.name).toList();
 
-  final choise = logger.select('Select a version:', options: versionsList);
+  final choise = logger.select('Select a version: ', options: versionsList);
 
   return choise;
 }


### PR DESCRIPTION
Because of the lack of the trailing space, the option appeared like `Select a version:1`. Now it looks like this: `Select a version: 1`