### PR TITLE
Issue #723 : New column Local in command List

### DIFF
--- a/lib/src/commands/list_command.dart
+++ b/lib/src/commands/list_command.dart
@@ -3,6 +3,7 @@ import 'package:mason_logger/mason_logger.dart';
 
 import '../services/cache_service.dart';
 import '../services/global_version_service.dart';
+import '../services/project_service.dart';
 import '../services/logger_service.dart';
 import '../services/releases_service/models/version_model.dart';
 import '../services/releases_service/releases_client.dart';
@@ -44,6 +45,7 @@ class ListCommand extends BaseCommand {
 
     final releases = await FlutterReleasesClient.getReleases();
     final globalVersion = GlobalVersionService.fromContext.getGlobal();
+    final localVersion = ProjectService.fromContext.findVersion();
 
     final table = Table()
       ..insertColumn(header: 'Version', alignment: TextAlignment.left)
@@ -51,7 +53,8 @@ class ListCommand extends BaseCommand {
       ..insertColumn(header: 'Flutter Version', alignment: TextAlignment.left)
       ..insertColumn(header: 'Dart Version', alignment: TextAlignment.left)
       ..insertColumn(header: 'Release Date', alignment: TextAlignment.left)
-      ..insertColumn(header: 'Global', alignment: TextAlignment.left);
+      ..insertColumn(header: 'Global', alignment: TextAlignment.left)
+      ..insertColumn(header: 'Local', alignment: TextAlignment.left);
 
     for (var version in cacheVersions) {
       var printVersion = version.name;
@@ -99,6 +102,9 @@ class ListCommand extends BaseCommand {
             version.dartSdkVersion ?? '',
             releaseDate,
             globalVersion == version ? green.wrap(dot)! : '',
+            localVersion == printVersion && localVersion != null
+                ? green.wrap(dot)!
+                : '',
           ],
         ])
         ..borderStyle = BorderStyle.square


### PR DESCRIPTION
Create a new column to show the current local version if the project has a local version configured. 

In a project with a custom version configured : 
![Screenshot 2024-06-04 at 12 34 16](https://github.com/leoafarias/fvm/assets/397927/9a6feb3b-39fd-48f7-a5ba-2b7b53801c4c)

In a project without configuration files present: 
![Screenshot 2024-06-04 at 12 40 05](https://github.com/leoafarias/fvm/assets/397927/dea25967-a72d-4a94-b39c-b2ee696a2807)

I'm open to write some test but I did't find a way. 