### PR TITLE
add documentation for command rerouting

### DIFF
--- a/docs/pages/documentation/guides/running-flutter.mdx
+++ b/docs/pages/documentation/guides/running-flutter.mdx
@@ -82,6 +82,40 @@ fv=".fvm/flutter_sdk/bin/flutter"
 
 </Callout>
 
+<Callout type="info">
+
+If you wish to reroute `flutter` and `dart` calls to FVM i.e. ensure that running `flutter` on the terminal internally runs `fvm flutter` then you could run the below commands.
+
+**On Mac**
+
+```bash
+sudo echo 'fvm flutter ${@:1}' > "/usr/local/bin/flutter" && sudo chmod +x /usr/local/bin/flutter
+sudo echo 'fvm dart ${@:1}' > "/usr/local/bin/dart" && sudo chmod +x /usr/local/bin/dart
+```
+
+**On Linux**
+
+```bash
+echo 'fvm flutter ${@:1}' > "$HOME/.local/bin/flutter" && chmod +x "$HOME/.local/bin/flutter"
+echo 'fvm dart ${@:1}' > "$HOME/.local/bin/dart" && chmod +x "$HOME/.local/bin/dart"
+```
+If you've installed flutter/dart using native package managers, the binaries might conflict with these new shortcuts so consider deleting the existing ones and taking a backup for easier restoration.
+
+If you wish to remove these reroutes, just delete the corresponding files as shown below:
+
+**On Mac**
+```bash
+sudo rm /usr/local/bin/flutter
+sudo rm /usr/local/bin/dart
+```
+
+**On Linux**
+```bash
+rm "$HOME/.local/bin/flutter"
+rm "$HOME/.local/bin/dart"
+```
+</Callout>
+
 ## Spawn Command
 
 Spawns a command on any installed Flutter SDK.


### PR DESCRIPTION
- This PR addresses command rerouting issue https://github.com/leoafarias/fvm/issues/719.

>I think we can add this as a tip in this section here:

@leoafarias  I'm unsure if I fully understood the primitive "tip", but I assumed it was an ` info callout`. It looks a little weird to have an info block that long unless its just me. But happy to hear your thoughts.

<img width="1222" alt="Screenshot 2024-06-06 at 6 39 35 PM" src="https://github.com/leoafarias/fvm/assets/1428864/4f8c027a-2da8-4dac-b818-68ae2155ba2c">
