### PR TITLE
fix(cosmetics): fvm has one newline too much

### DIFF
--- a/lib/src/runner.dart
+++ b/lib/src/runner.dart
@@ -185,9 +185,6 @@ class FvmCommandRunner extends CompletionCommandRunner<int> {
       _printTrace(stackTrace);
 
       return ExitCode.unavailable.code;
-    } finally {
-      // Add spacer after the last line always
-      logger.spacer;
     }
   }
 


### PR DESCRIPTION
Hey there, first of all: Thank you very much for your work with fvm! I really really love the tool and if I have improvements for the future, I am going to contribute and try to help that way!

I was facing a very annoying and draining issue that occurred after reinstalling my laptop, which was that I could not generate protobuffers for dart anymore.
I was pulling my hair out trying to understand, what was happening. And now I found the issue, you can see it in the changes of this PR.

I am wondering if you had any special use case why this extra newline was needed. If you ask me, FVM should not alter the output of at least the dart calls, as to not break compatibility with tools that are developed against plain dart, like in my case.
FVM should be a seamless wrapper and therefore not add this newline.
I could not find a FVM command that looks weird if this newline is not added, so please let me know why you added it?

Otherwise I would very much appreciate it, if it could be removed. Because then I don't have to break my back trying to get protoc to work while still using FVM.

The issues I opened already, but were nowhere close to the real source of the problem, are the following:
- https://github.com/google/protobuf.dart/issues/923
- https://github.com/golang/protobuf/issues/1622