### PR TITLE
fix: unsupported architecture on arm64

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -18,7 +18,7 @@ esac
 
 case "$ARCH" in
   x86_64)  ARCH='x64' ;;
-  arm64)   ARCH='arm64' ;;
+  arm64|aarch64)   ARCH='arm64' ;;
   armv7l)  ARCH='arm' ;;
   *)       log_message "Unsupported architecture"; exit 1 ;;
 esac


### PR DESCRIPTION
```
$ docker run --rm debian:stable uname -m
aarch64
```
it isn't arm64 on linux as far as I can tell (it is arm64 on darwin)