### PR TITLE
Update vscode.mdx

### DIFF
--- a/docs/pages/documentation/guides/vscode.mdx
+++ b/docs/pages/documentation/guides/vscode.mdx
@@ -24,7 +24,7 @@ Upon detection, FVM automatically updates the .vscode/settings.json file within 
 
 ```json
 {
-  "dart.flutterSdkPath": ".fvm/versions/stable"
+  "dart.flutterSdkPath": "~/.fvm/versions/stable"
 }
 ```
 


### PR DESCRIPTION
Setting the dart.flutterSdkPath to ".fvm/versions/stable" did not work for me. Because with that it looks into the project folder and not in the home folder of the user. Where the .fvm folder is located. So only by referencing to the home directory with "~/.fvm/versions/stable" worked as it should.