### PR TITLE
Update list_command.dart

### DIFF
--- a/lib/src/commands/list_command.dart
+++ b/lib/src/commands/list_command.dart
@@ -1,6 +1,7 @@
 import 'package:dart_console/dart_console.dart';
 import 'package:mason_logger/mason_logger.dart';
 
+import '../models/flutter_version_model.dart';
 import '../services/cache_service.dart';
 import '../services/global_version_service.dart';
 import '../services/logger_service.dart';
@@ -11,6 +12,61 @@ import '../utils/context.dart';
 import '../utils/get_directory_size.dart';
 import '../utils/helpers.dart';
 import 'base_command.dart';
+
+// ERRORS
+enum ListCommandException implements Exception {
+  noSDKsInstalled;
+}
+
+// SERVICE
+class ListCommandService {
+  static Future<ListCommandData> run() async {
+    final cacheVersions = await CacheService.fromContext.getAllVersions();
+
+    final directorySize = await getFullDirectorySize(cacheVersions);
+
+    if (cacheVersions.isEmpty) {
+      throw ListCommandException.noSDKsInstalled;
+    }
+
+    final releases = await FlutterReleasesClient.getReleases();
+    final globalVersion = GlobalVersionService.fromContext.getGlobal();
+    final localVersion = ProjectService.fromContext.findVersion();
+
+    final versions = <VersionInfo>[];
+
+    for (var version in cacheVersions) {
+      FlutterSdkRelease? latestRelease;
+
+      if (version.isChannel && !version.isMaster) {
+        latestRelease = releases.getLatestChannelRelease(version.name);
+      }
+
+      final release =
+          releases.getReleaseFromVersion(version.flutterSdkVersion ?? '');
+
+      final versionInfo = VersionInfo(
+        name: version.name,
+        type: version.type,
+        flutterSdkVersion: version.flutterSdkVersion,
+        dartSdkVersion: version.dartSdkVersion,
+        release: release,
+        isGlobal: globalVersion == version,
+        isLocal: localVersion == version.name && localVersion != null,
+        needsSetup: version.isNotSetup,
+        latestRelease: latestRelease,
+      );
+
+      versions.add(versionInfo);
+    }
+
+    return ListCommandData(
+      versions: versions,
+      directorySize: directorySize,
+      versionsCachePath: ctx.versionsCachePath,
+    );
+  }
+}
 
 /// List installed SDK Versions
 class ListCommand extends BaseCommand {
@@ -25,17 +81,75 @@ class ListCommand extends BaseCommand {
 
   @override
   Future<int> run() async {
-    final cacheVersions = await CacheService.fromContext.getAllVersions();
+    final ui = ListCommandUI(logger: logger);
 
-    final directorySize = await getFullDirectorySize(cacheVersions);
+    try {
+      final data = await ListCommandService.run();
+      ui.render(data);
+    } on ListCommandException catch (e) {
+      switch (e) {
+        case ListCommandException.noSDKsInstalled:
+          ui.renderNoSDKsInstalled();
+      }
+    }
 
-    // Print where versions are stored
+    return ExitCode.success.code;
+  }
+
+  @override
+  List<String> get aliases => ['ls'];
+}
+
+// DATA
+class ListCommandData {
+  final List<VersionInfo> versions;
+  final int directorySize;
+  final String versionsCachePath;
+
+  const ListCommandData({
+    required this.versions,
+    required this.directorySize,
+    required this.versionsCachePath,
+  });
+}
+
+class VersionInfo {
+  final String name;
+  final VersionType type;
+  final String? flutterSdkVersion;
+  final String? dartSdkVersion;
+  final FlutterSdkRelease? release;
+  final bool isGlobal;
+  final bool isLocal;
+  final bool needsSetup;
+  final FlutterSdkRelease? latestRelease;
+
+  const VersionInfo({
+    required this.name,
+    required this.type,
+    this.flutterSdkVersion,
+    this.dartSdkVersion,
+    this.release,
+    required this.isGlobal,
+    required this.isLocal,
+    required this.needsSetup,
+    this.latestRelease,
+  });
+}
+
+// UI
+class ListCommandUI {
+  final LoggerService logger;
+
+  const ListCommandUI({required this.logger});
+
+  void render(ListCommandData data) {
     logger
-      ..info('Cache directory:  ${cyan.wrap(ctx.versionsCachePath)}')
-      ..info('Directory Size: ${formatBytes(directorySize)}')
+      ..info('Cache directory:  ${cyan.wrap(data.versionsCachePath)}')
+      ..info('Directory Size: ${formatBytes(data.directorySize)}')
       ..spacer;
 
-    if (cacheVersions.any((e) => e.isNotSetup)) {
+    if (data.versions.any((e) => e.needsSetup)) {
       logger
         ..warn(
           'Some versions might still require finishing setup - SDKs have been cloned, but they have not downloaded their dependencies.',
@@ -45,17 +159,6 @@ class ListCommand extends BaseCommand {
         )
         ..spacer;
     }
-    if (cacheVersions.isEmpty) {
-      logger
-        ..info('No SDKs have been installed yet. Flutter. SDKs')
-        ..info('installed outside of fvm will not be displayed.');
-
-      return ExitCode.success.code;
-    }
-
-    final releases = await FlutterReleasesClient.getReleases();
-    final globalVersion = GlobalVersionService.fromContext.getGlobal();
-    final localVersion = ProjectService.fromContext.findVersion();
 
     final table = Table()
       ..insertColumn(header: 'Version', alignment: TextAlignment.left)
@@ -66,20 +169,13 @@ class ListCommand extends BaseCommand {
       ..insertColumn(header: 'Global', alignment: TextAlignment.left)
       ..insertColumn(header: 'Local', alignment: TextAlignment.left);
 
-    for (var version in cacheVersions) {
-      var printVersion = version.name;
-      FlutterSdkRelease? latestRelease;
-
-      if (version.isChannel && !version.isMaster) {
-        latestRelease = releases.getLatestChannelRelease(version.name);
-      }
-
-      final release =
-          releases.getReleaseFromVersion(version.flutterSdkVersion ?? '');
-
+    for (var version in data.versions) {
       String releaseDate = '';
       String channel = '';
 
+      final release = version.release;
+
+      print(release);
       if (release != null) {
         releaseDate = friendlyDate(release.releaseDate);
         channel = release.channel.name;
@@ -88,10 +184,13 @@ class ListCommand extends BaseCommand {
       String flutterSdkVersion = version.flutterSdkVersion ?? '';
 
       String getVersionOutput() {
-        if (version.isNotSetup) {
+        if (version.needsSetup) {
           return flutterSdkVersion = '${yellow.wrap('Need setup*')}';
         }
-        if (latestRelease != null && version.isChannel) {
+
+        final latestRelease = version.latestRelease;
+
+        if (latestRelease != null && version.type == VersionType.channel) {
           // If its not the latest version
           if (latestRelease.version != version.flutterSdkVersion) {
             return '$flutterSdkVersion $rightArrow ${(green.wrap(latestRelease.version))}';
@@ -106,15 +205,13 @@ class ListCommand extends BaseCommand {
       table
         ..insertRows([
           [
-            printVersion,
+            version.name,
             channel,
             getVersionOutput(),
             version.dartSdkVersion ?? '',
             releaseDate,
-            globalVersion == version ? green.wrap(dot)! : '',
-            localVersion == printVersion && localVersion != null
-                ? green.wrap(dot)!
-                : '',
+            version.isGlobal ? green.wrap(dot)! : '',
+            version.isLocal ? green.wrap(dot)! : '',
           ],
         ])
         ..borderStyle = BorderStyle.square
@@ -122,11 +219,13 @@ class ListCommand extends BaseCommand {
         ..borderType = BorderType.grid
         ..headerStyle = FontStyle.bold;
     }
-    logger.info(table.toString());
 
-    return ExitCode.success.code;
+    logger.info(table.toString());
   }
 
-  @override
-  List<String> get aliases => ['ls'];
+  void renderNoSDKsInstalled() {
+    logger
+      ..info('No SDKs have been installed yet. Flutter. SDKs')
+      ..info('installed outside of fvm will not be displayed.');
+  }
 }


### PR DESCRIPTION
I'm planning to reuse the logic behind FVM to create an app Flutter that offers a GUI. As part of this project, I would like to propose a new architecture for the `Command`s. The main goal of this new architecture is to create a new layer that separates the logic of gathering information from the UI, which is rendered on the terminal. This way, we can reuse all the classes and logic used to build the UI in other applications.

On the **left side is the current version** and on the other side is the **new proposal**.
![Blank Diagram Lucidchart](https://github.com/user-attachments/assets/3c1bac3c-4f6c-485a-9a6b-03e798501635)


