### PR TITLE
fix: Fix FormatException caused by '@' in  Custom Flutter Version

### DIFF
--- a/lib/src/models/flutter_version_model.dart
+++ b/lib/src/models/flutter_version_model.dart
@@ -58,8 +58,12 @@ class FlutterVersion with FlutterVersionMappable {
       : type = VersionType.release;
 
   factory FlutterVersion.parse(String version) {
-    final parts = version.split('@');
+    // Check if its custom.
+    if (version.startsWith('custom_')) {
+      return FlutterVersion.custom(version);
+    }
 
+    final parts = version.split('@');
     if (parts.length == 2) {
       final channel = parts.last;
       if (kFlutterChannels.contains(channel)) {
@@ -67,10 +71,6 @@ class FlutterVersion with FlutterVersionMappable {
       }
 
       throw FormatException('Invalid version format');
-    }
-    // Check if its custom.
-    if (version.startsWith('custom_')) {
-      return FlutterVersion.custom(version);
     }
 
     // Check if its commit

--- a/test/models/flutter_version_model_test.dart
+++ b/test/models/flutter_version_model_test.dart
@@ -80,6 +80,13 @@ void main() {
       expect(version.type, VersionType.custom);
     });
 
+    test('custom constructor', () {
+      final version = FlutterVersion.custom('custom_3.7.0@huawei');
+      expect(version.name, 'custom_3.7.0@huawei');
+      expect(version.releaseFromChannel, isNull);
+      expect(version.type, VersionType.custom);
+    });
+
     test('release constructor', () {
       final version =
           FlutterVersion.release('1.0.0', releaseFromChannel: 'stable');
@@ -105,6 +112,13 @@ void main() {
     test('parse method - custom version', () {
       final version = FlutterVersion.parse('custom_123');
       expect(version.name, 'custom_123');
+      expect(version.releaseFromChannel, isNull);
+      expect(version.type, VersionType.custom);
+    });
+
+    test('parse method - custom version', () {
+      final version = FlutterVersion.parse('custom_3.6.0@huawei');
+      expect(version.name, 'custom_3.6.0@huawei');
       expect(version.releaseFromChannel, isNull);
       expect(version.type, VersionType.custom);
     });
@@ -158,6 +172,12 @@ void main() {
 
     test('isCustom getter', () {
       final version = FlutterVersion.custom('custom_123');
+      expect(version.isCustom, isTrue);
+    });
+
+
+    test('isCustom getter', () {
+      final version = FlutterVersion.custom('custom_3.22.0@huawei');
       expect(version.isCustom, isTrue);
     });
 


### PR DESCRIPTION
As described in the documentation on [https://fvm.app/documentation/advanced/custom-version](https://fvm.app/documentation/advanced/custom-version), when we want to manage a custom version of the Flutter SDK in FVM, we need to use `custom_` as a prefix for the version. However, it does not support naming conventions that include an `@` symbol, such as `custom_3.7.0@huawei`. This is because previously, the `FlutterVersion#parse(String version)` method would first attempt to parse a `FlutterVersion.release` type of `FlutterVersion`, and would split the string at the `@` symbol. This would cause parsing errors for custom version numbers like `custom_3.7.0@huawei`. Therefore, I have prioritized the parsing of `FlutterVersion.custom` to ensure that such `FlutterVersion` can be successfully parsed.
