### PR TITLE
fix: incorrect fvm spawn example

### DIFF
--- a/docs/pages/documentation/guides/basic-commands.mdx
+++ b/docs/pages/documentation/guides/basic-commands.mdx
@@ -268,14 +268,14 @@ This command is particularly useful when you need to run a Flutter command (such
 To build your Flutter project using version `2.5.0` of the Flutter SDK:
 
 ```bash
-fvm spawn 2.5.0 flutter build
+fvm spawn 2.5.0 build
 ```
 
 **Running Tests with a Different SDK Version**:  
 If you need to run tests using a particular Flutter SDK version:
 
 ```bash
-fvm spawn 2.2.3 flutter test
+fvm spawn 2.2.3 test
 ```
 
 ## Exec


### PR DESCRIPTION
the command should be `fvm spawn x.x.x build` not `fvm spawn x.x.x flutter build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Simplified command examples in the guides by removing redundant references.
  - Adjusted examples for building and testing commands for clarity.
  - Improved formatting for command examples to enhance readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->