### PR TITLE
Added Dart SDK column in releases command output table

### DIFF
--- a/lib/src/commands/releases_command.dart
+++ b/lib/src/commands/releases_command.dart
@@ -57,6 +57,7 @@ class ReleasesCommand extends BaseCommand {
 
     final table = createTable()
       ..insertColumn(header: 'Version', alignment: TextAlignment.left)
+      ..insertColumn(header: 'Dart SDK', alignment: TextAlignment.left)
       ..insertColumn(header: 'Release Date', alignment: TextAlignment.left)
       ..insertColumn(header: 'Channel', alignment: TextAlignment.left);
 
@@ -77,6 +78,7 @@ class ReleasesCommand extends BaseCommand {
 
       table.insertRow([
         release.version,
+        release.dartSdkVersion ?? 'n/a',
         friendlyDate(release.releaseDate),
         channelLabel,
       ]);


### PR DESCRIPTION
In case no dart sdk is found, outputs `n/a`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The release details now include an additional "Dart SDK" column that displays the Dart SDK version for each release. If the version is not provided, it defaults to "n/a", enhancing the overall release information for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->