### PR TITLE
Replace discontinued pubspec with pubspec_parse (fixes #683)

### DIFF
--- a/docs/public/install.sh
+++ b/docs/public/install.sh
@@ -11,25 +11,34 @@ ARCH="$(uname -m)"
 
 # Map to FVM naming
 case "$OS" in
-  Linux*)  OS='linux' ;;
-  Darwin*) OS='macos' ;;
-  *)       log_message "Unsupported OS"; exit 1 ;;
+Linux*) OS='linux' ;;
+Darwin*) OS='macos' ;;
+*)
+    log_message "Unsupported OS"
+    exit 1
+    ;;
 esac
 
 case "$ARCH" in
-  x86_64)  ARCH='x64' ;;
-  arm64)   ARCH='arm64' ;;
-  armv7l)  ARCH='arm' ;;
-  *)       log_message "Unsupported architecture"; exit 1 ;;
+  x86_64) ARCH='x64' ;;
+  arm64|aarch64) ARCH='arm64' ;;
+  armv7l) ARCH='arm' ;;
+  *) log_message "Unsupported architecture"; exit 1 ;;
 esac
 
 # Terminal colors setup
-Color_Off='\033[0m'       # Reset
-Green='\033[0;32m'        # Green
-Red='\033[0;31m'          
+
+Color_Off='\033[0m' # Reset
+Green='\033[0;32m'  # Green
+Red='\033[0;31m'
+Bold_White='\033[1m' # Bold White
 
 success() {
     log_message "${Green}$1${Color_Off}"
+}
+
+info_bold() {
+    log_message "${Bold_White}$1${Color_Off}"
 }
 
 error() {
@@ -37,47 +46,67 @@ error() {
     exit 1
 }
 
+# Check if running as root
+if [[ $(id -u) -eq 0 ]]; then
+    error "Should not run as root"
+fi
+
 # Log detected OS and architecture
 log_message "Detected OS: $OS"
 log_message "Detected Architecture: $ARCH"
 
 # Check for curl
-if ! command -v curl &> /dev/null; then
+if ! command -v curl &>/dev/null; then
     error "curl is required but not installed."
+fi
+
+# Check for escalation tool
+for cmd in sudo doas; do
+    if command -v "$cmd" &>/dev/null; then
+        ESCALATION_TOOL="$cmd"
+        break
+    fi
+done
+
+if [ -z "$ESCALATION_TOOL" ]; then
+    error "Cannot find sudo or doas for escalated privileges"
 fi
 
 # Get installed FVM version if exists
 INSTALLED_FVM_VERSION=""
-if command -v fvm &> /dev/null; then
+if command -v fvm &>/dev/null; then
     INSTALLED_FVM_VERSION=$(fvm --version 2>&1) || error "Failed to fetch installed FVM version."
 fi
 
 # Define the URL of the FVM binary
 if [ -z "$1" ]; then
-  FVM_VERSION=$(curl -s https://api.github.com/repos/leoafarias/fvm/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
-  if [ -z "$FVM_VERSION" ]; then
-      error "Failed to fetch latest FVM version."
-  fi
+    FVM_VERSION=$(curl -s https://api.github.com/repos/leoafarias/fvm/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+    if [ -z "$FVM_VERSION" ]; then
+        error "Failed to fetch latest FVM version."
+    fi
 else
-  FVM_VERSION="$1"
+    FVM_VERSION="$1"
 fi
 
 log_message "Installing FVM version $FVM_VERSION."
 
 # Setup installation directory and symlink
 FVM_DIR="$HOME/.fvm_flutter"
-FMV_DIR_BIN="$FVM_DIR/bin"
+FVM_DIR_BIN="$FVM_DIR/bin"
+
 SYMLINK_TARGET="/usr/local/bin/fvm"
 
 
 # Create FVM directory if it doesn't exist
-mkdir -p "$FVM_DIR" || error "Failed to create FVM directory: $FVM_DIR."
+mkdir -p "$FVM_DIR_BIN" || error "Failed to create FVM directory: $FVM_DIR_BIN."
 
-# Check if FVM_DIR exists, and if it does delete it
-if [ -d "$FMV_DIR_BIN" ]; then
+
+# Check if FVM_DIR_BIN exists, and if it does delete it
+
+if [ -d "$FVM_DIR_BIN" ]; then
     log_message "FVM bin directory already exists. Removing it."
-    if ! rm -rf "$FMV_DIR_BIN"; then
-        error "Failed to remove existing FVM directory: $FMV_DIR_BIN."
+    if ! rm -rf "$FVM_DIR_BIN"; then
+        error "Failed to remove existing FVM directory: $FVM_DIR_BIN."
     fi
 fi
 
@@ -86,7 +115,6 @@ URL="https://github.com/leoafarias/fvm/releases/download/$FVM_VERSION/fvm-$FVM_V
 if ! curl -L "$URL" -o fvm.tar.gz; then
     error "Download failed. Check your internet connection and URL: $URL"
 fi
-
 
 # Extract binary to the new location
 if ! tar xzf fvm.tar.gz -C "$FVM_DIR" 2>&1; then
@@ -99,19 +127,146 @@ if ! rm -f fvm.tar.gz; then
 fi
 
 # Rename FVM_DIR/fvm to FVM_DIR/bin
-if ! mv "$FVM_DIR/fvm" "$FMV_DIR_BIN"; then
+if ! mv "$FVM_DIR/fvm" "$FVM_DIR_BIN"; then
     error "Failed to move fvm to bin directory."
 fi
 
+
 # Create a symlink
-if ! ln -sf "$FMV_DIR_BIN/fvm" "$SYMLINK_TARGET"; then
+if ! "$ESCALATION_TOOL" ln -sf "$FVM_DIR_BIN/fvm" "$SYMLINK_TARGET"; then
     error "Failed to create symlink."
 fi
 
-# Verify installation
-if ! command -v fvm &> /dev/null; then
-    error "Installation verification failed. FVM may not be in PATH or failed to execute."
+tildify() {
+    if [[ $1 = $HOME/* ]]; then
+        local replacement=\~/
+
+        echo "${1/$HOME\//$replacement}"
+    else
+        echo "$1"
+    fi
+}
+
+tilde_FVM_DIR_BIN=$(tildify "$FVM_DIR_BIN")
+refresh_command=''
+
+case $(basename "$SHELL") in
+fish)
+    commands=(
+        "set --export PATH $FVM_DIR_BIN \$PATH"
+    )
+
+    fish_config=$HOME/.config/fish/config.fish
+    tilde_fish_config=$(tildify "$fish_config")
+
+    if [[ -w $fish_config ]]; then
+        {
+            echo -e '\n# FVM'
+
+            for command in "${commands[@]}"; do
+                echo "$command"
+            done
+        } >>"$fish_config"
+
+        log_message "Added \"$tilde_FVM_DIR_BIN\" to \$PATH in \"$tilde_fish_config\""
+        refresh_command="source $tilde_fish_config"
+
+    else
+        log_message "Manually add the directory to $tilde_fish_config (or similar):"
+
+        for command in "${commands[@]}"; do
+            info_bold "  $command"
+        done
+    fi
+    ;;
+zsh)
+    commands=(
+        "export PATH=\"$FVM_DIR_BIN:\$PATH\""
+    )
+
+    zsh_config=$HOME/.zshrc
+    tilde_zsh_config=$(tildify "$zsh_config")
+
+    if [[ -w $zsh_config ]]; then
+        {
+            echo -e '\n# FVM'
+
+            for command in "${commands[@]}"; do
+                echo "$command"
+            done
+        } >>"$zsh_config"
+
+        log_message "Added \"$tilde_FVM_DIR_BIN\" to \$PATH in \"$tilde_zsh_config\""
+        refresh_command="source $zsh_config"
+
+    else
+        log_message "Manually add the directory to $tilde_zsh_config (or similar):"
+
+        for command in "${commands[@]}"; do
+            info_bold "  $command"
+        done
+    fi
+    ;;
+bash)
+    commands=(
+        "export PATH=$FVM_DIR_BIN:\$PATH"
+    )
+
+    bash_configs=(
+        "$HOME/.bashrc"
+        "$HOME/.bash_profile"
+    )
+
+    if [[ ${XDG_CONFIG_HOME:-} ]]; then
+        bash_configs+=(
+            "$XDG_CONFIG_HOME/.bash_profile"
+            "$XDG_CONFIG_HOME/.bashrc"
+            "$XDG_CONFIG_HOME/bash_profile"
+            "$XDG_CONFIG_HOME/bashrc"
+        )
+    fi
+
+    set_manually=true
+    for bash_config in "${bash_configs[@]}"; do
+        tilde_bash_config=$(tildify "$bash_config")
+
+        if [[ -w $bash_config ]]; then
+            {
+                echo -e '\n# FVM'
+
+                for command in "${commands[@]}"; do
+                    echo "$command"
+                done
+            } >>"$bash_config"
+
+            log_message "Added \"$tilde_FVM_DIR_BIN\" to \$PATH in \"$tilde_bash_config\""
+            refresh_command="source $bash_config"
+            set_manually=false
+            break
+        fi
+    done
+
+    if [[ $set_manually = true ]]; then
+        log_message "Manually add the directory to $tilde_bash_config (or similar):"
+
+        for command in "${commands[@]}"; do
+            info_bold "  $command"
+        done
+    fi
+    ;;
+*)
+    log_message 'Manually add the directory to ~/.bashrc (or similar):'
+    info_bold "  export PATH=\"$FVM_DIR_BIN:\$PATH\""
+    ;;
+esac
+
+echo
+log_message "To get started, run:"
+echo
+
+
+if [[ $refresh_command ]]; then
+    info_bold "  $refresh_command"
 fi
 
-INSTALLED_FVM_VERSION=$(fvm --version 2>&1) || error "Failed to verify installed FVM version."
-success "FVM $INSTALLED_FVM_VERSION installed successfully."
+info_bold "  fvm --help"

--- a/docs/public/uninstall.sh
+++ b/docs/public/uninstall.sh
@@ -1,15 +1,21 @@
 #!/bin/bash
 
+# Detect OS
+OS="$(uname -s)"
+
+# Map to FVM naming
+case "$OS" in
+Linux*) OS='linux' ;;
+Darwin*) OS='macos' ;;
+*)
+    log_message "Unsupported OS"
+    exit 1
+    ;;
+esac
+
 # Define the FVM directory and binary path
 FVM_DIR="$HOME/.fvm_flutter"
-BIN_LINK="/usr/local/bin/fvm"
-
-# Check if FVM is installed
-if ! command -v fvm &> /dev/null
-then
-    echo "FVM is not installed. Exiting."
-    exit 1
-fi
+FVM_DIR_BIN="$FVM_DIR/bin"
 
 # Remove the FVM binary
 echo "Uninstalling FVM..."
@@ -18,15 +24,10 @@ rm -rf "$FVM_DIR" || {
     exit 1
 }
 
-# Remove the symlink
-rm -f "$BIN_LINK" || {
-    echo "Failed to remove FVM symlink: $BIN_LINK."
-    exit 1
-}
+echo "You can remove \"export PATH=$FVM_DIR_BIN:\$PATH\" from your ~/.bashrc, ~/.zshrc (or similar)"
 
 # Check if uninstallation was successful
-if command -v fvm &> /dev/null
-then
+if command -v fvm &>/dev/null; then
     echo "Uninstallation failed. Please try again later."
     exit 1
 fi

--- a/lib/src/models/project_model.dart
+++ b/lib/src/models/project_model.dart
@@ -4,7 +4,7 @@ import 'dart:io';
 import 'package:dart_mappable/dart_mappable.dart';
 import 'package:path/path.dart';
 import 'package:pub_semver/pub_semver.dart';
-import 'package:pubspec/pubspec.dart';
+import 'package:pubspec_parse/pubspec_parse.dart';
 
 import '../services/logger_service.dart';
 import '../utils/constants.dart';
@@ -13,6 +13,8 @@ import 'config_model.dart';
 import 'flutter_version_model.dart';
 
 part 'project_model.mapper.dart';
+
+typedef PubSpec = Pubspec;
 
 /// Represents a Flutter project.
 ///
@@ -79,7 +81,7 @@ class Project with ProjectMappable {
 
     final pubspecFile = File(join(path, 'pubspec.yaml'));
     final pubspec = pubspecFile.existsSync()
-        ? PubSpec.fromYamlString(pubspecFile.readAsStringSync())
+        ? PubSpec.parse(pubspecFile.readAsStringSync())
         : null;
 
     return Project(config: config, path: path, pubspec: pubspec);
@@ -179,7 +181,7 @@ class Project with ProjectMappable {
   /// Retrieves the Flutter SDK constraint from the pubspec.yaml file.
   ///
   /// Returns `null` if the constraint is not defined.
-  VersionConstraint? get sdkConstraint => pubspec?.environment?.sdkConstraint;
+  VersionConstraint? get sdkConstraint => pubspec?.environment?['sdk'];
 }
 
 String _fvmPath(String path) {
@@ -224,5 +226,5 @@ class PubspecMapper extends SimpleMapper<PubSpec> {
 
   @override
   // ignore: avoid-dynamic
-  dynamic encode(PubSpec self) => self.toJson();
+  dynamic encode(PubSpec self) => self.toString();
 }

--- a/lib/src/models/project_model.mapper.dart
+++ b/lib/src/models/project_model.mapper.dart
@@ -27,8 +27,8 @@ class ProjectMapper extends ClassMapperBase<Project> {
       Field('config', _$config);
   static String _$path(Project v) => v.path;
   static const Field<Project, String> _f$path = Field('path', _$path);
-  static PubSpec? _$pubspec(Project v) => v.pubspec;
-  static const Field<Project, PubSpec> _f$pubspec = Field('pubspec', _$pubspec);
+  static Pubspec? _$pubspec(Project v) => v.pubspec;
+  static const Field<Project, Pubspec> _f$pubspec = Field('pubspec', _$pubspec);
   static String _$name(Project v) => v.name;
   static const Field<Project, String> _f$name = Field('name', _$name);
   static FlutterVersion? _$pinnedVersion(Project v) => v.pinnedVersion;
@@ -159,7 +159,7 @@ extension ProjectValueCopy<$R, $Out> on ObjectCopyWith<$R, Project, $Out> {
 abstract class ProjectCopyWith<$R, $In extends Project, $Out>
     implements ClassCopyWith<$R, $In, $Out> {
   ProjectConfigCopyWith<$R, ProjectConfig, ProjectConfig>? get config;
-  $R call({ProjectConfig? config, String? path, PubSpec? pubspec});
+  $R call({ProjectConfig? config, String? path, Pubspec? pubspec});
   ProjectCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t);
 }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -13,7 +13,7 @@ packages:
     dependency: transitive
     description: dart
     source: sdk
-    version: "0.3.2"
+    version: "0.3.1"
   analyzer:
     dependency: transitive
     description:
@@ -450,10 +450,10 @@ packages:
     dependency: transitive
     description:
       name: macros
-      sha256: "0acaed5d6b7eab89f63350bccd82119e6c602df0f391260d0e32b5e23db79536"
+      sha256: "6245feb91dfa3693100d2e680f6c5614405b1623b555b4b3cba3cb88a3beb5c2"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.2-main.4"
+    version: "0.1.2-main.3"
   mason_logger:
     dependency: "direct main"
     description:
@@ -574,30 +574,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.4.0"
-  pubspec:
-    dependency: "direct main"
-    description:
-      name: pubspec
-      sha256: f534a50a2b4d48dc3bc0ec147c8bd7c304280fff23b153f3f11803c4d49d927e
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.3.0"
   pubspec_parse:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: pubspec_parse
       sha256: c799b721d79eb6ee6fa56f00c04b472dcd44a30d258fac2174a6ec57302678f8
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
-  quiver:
-    dependency: transitive
-    description:
-      name: quiver
-      sha256: ea0b925899e64ecdfbf9c7becb60d5b50e706ade44a85b2363be2a22d88117d2
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.2.2"
   retry:
     dependency: transitive
     description:
@@ -782,14 +766,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.2"
-  uri:
-    dependency: transitive
-    description:
-      name: uri
-      sha256: "889eea21e953187c6099802b7b4cf5219ba8f3518f604a1033064d45b1b8268a"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0"
   vm_service:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   dart_console: ^1.2.0
   tint: ^2.0.1
   stack_trace: ^1.11.1
-  pubspec: ^2.3.0
+  pubspec_parse: ^1.3.0
   jsonc: ^0.0.3
   dart_mappable: ^4.2.2
   cli_completion: ^0.5.0


### PR DESCRIPTION
I tried to do the minimal changes so the tests would still pass.  The package `pubspec` implementation requires that `hosted` dependencies have a `version` value. That is not required by dart, resolving to the latest compatible version when ommited. The package `pubspec_parse`, recommended as replacement for `pubspec` has no such limitation.

The change is not 1:1 due to the missing `toJson` method on the `Pubspec` class, so for now I changed the method `encode` on `PubspecMapper` to return `toString`. It didn't break on normal usage but I didn't go as deep to understand the implications.

With this fix we will be able to use fvm without changes. We use a lot of internal hosted packages, so #683 is a blocker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the installation process with robust error handling, secure privilege checks (preventing execution as root), expanded support for additional architectures (including aarch64), and clear instructions for updating your PATH.
	- Streamlined the uninstallation process with improved OS detection and straightforward guidance for cleaning up environment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->