### PR TITLE
feat: accept bin dir as variable to installation script

### DIFF
--- a/scripts/install.md
+++ b/scripts/install.md
@@ -8,6 +8,13 @@ Run the command below in your terminal.
 curl -fsSL https://fvm.app/install.sh | bash
 ```
 
+You can customise the directory fvm is installed to by setting `SYMLINK_DIR` in
+your environment as so:
+
+```bash
+curl -fsSL https://fvm.app/install.sh | SYMLINK_DIR=$HOME/.local/bin bash
+```
+
 ### Install FVM on Windows
 
 **Run as Admin**: Open PowerShell as Administrator.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -94,8 +94,7 @@ log_message "Installing FVM version $FVM_VERSION."
 FVM_DIR="$HOME/.fvm_flutter"
 FVM_DIR_BIN="$FVM_DIR/bin"
 
-SYMLINK_TARGET="/usr/local/bin/fvm"
-
+SYMLINK_TARGET="${SYMLINK_DIR:-/usr/local/bin}/fvm"
 
 # Create FVM directory if it doesn't exist
 mkdir -p "$FVM_DIR_BIN" || error "Failed to create FVM directory: $FVM_DIR_BIN."


### PR DESCRIPTION
Allows users to define the installation directory on *nix machines when running `install.sh` by setting the `SYMLINK_DIR` variable. If not set this defaults to `/usr/local/bin`.

The purpose behind this change is to allow users to define an installation directory that does not require running the script with elevated privileges on Linux

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled flexible installation by allowing users to specify a custom directory during setup.
  
- **Documentation**
  - Updated installation instructions with examples to guide users on setting a custom installation directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->