### PR TITLE
Added support to arm64 docker images

### DIFF
--- a/.github/workflows/deploy_docker.yml
+++ b/.github/workflows/deploy_docker.yml
@@ -15,7 +15,7 @@ jobs:
             uses: ./.github/actions/prepare
     
           - name: Set up QEMU
-            uses: docker/setup-qemu-action@v1
+            uses: docker/setup-qemu-action@v3
     
           - name: Set up Docker Buildx
             uses: docker/setup-buildx-action@v1
@@ -31,6 +31,7 @@ jobs:
             uses: docker/build-push-action@v5
             with:
               file: ./.docker/Dockerfile
+              platforms: linux/amd64,linux/arm64/v8
               push: true
               tags: leoafarias/fvm:latest
     

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,7 @@ jobs:
         uses: ./.github/actions/prepare
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
 
       - name: Get and modify tag name
         id: get_tag_name
@@ -123,5 +123,6 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           file: ./.docker/Dockerfile
+          platforms: linux/amd64,linux/arm64/v8
           push: true
           tags: leoafarias/fvm:{{ steps.get_tag_name.outputs.modified_tag_name}}


### PR DESCRIPTION
Fixes #762

Because of the spreading of Arm64 machines (especially Ampere) on cloud platforms, it would be quite helpful to have a docker image targeting this architecture