### PR TITLE
Fix typo in example README

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -1,6 +1,6 @@
 # Example
 
-The following is a step by step if you want to run an specific version of Flutter within a project.
+The following is a step by step if you want to run a specific version of Flutter within a project.
 
 First choose the version you would like to install and cache on your machine.
 


### PR DESCRIPTION
## Summary
- correct the phrase "run an specific version" to "run a specific version" in example README

## Testing
- `dart test -p vm` *(fails: `dart: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68430c228c3c83319278b08b2191ed00