### PR TITLE
Fix comment typo in project update workflow

### DIFF
--- a/lib/src/workflows/update_project_references.workflow.dart
+++ b/lib/src/workflows/update_project_references.workflow.dart
@@ -18,7 +18,7 @@ class UpdateProjectReferencesWorkflow extends Workflow {
 
   const UpdateProjectReferencesWorkflow(super.context);
 
-  /// Updates the link to make sure its always correct
+  /// Updates the link to make sure it's always correct
   ///
   /// This method updates the .fvm symlink in the provided [project] to point to the cache
   /// directory of the currently pinned Flutter SDK version. It also cleans up legacy links


### PR DESCRIPTION
## Summary
- fix typo in `_updateLocalSdkReference` doc comment

## Testing
- `dart format -o none lib/src/workflows/update_project_references.workflow.dart` *(fails: `dart: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68430c28c0f883319c2629f40b6a2b10