### PR TITLE
Handle missing git

### DIFF
--- a/lib/src/workflows/ensure_cache.workflow.dart
+++ b/lib/src/workflows/ensure_cache.workflow.dart
@@ -80,8 +80,16 @@ class EnsureCacheWorkflow extends Workflow {
   }
 
   void _validateGit() {
-    final isGitInstalled = Process.runSync('git', ['--version']).exitCode == 0;
-    if (!isGitInstalled) {
+    try {
+      // `Process.runSync` throws a [ProcessException] when the executable
+      // cannot be found. If Git is installed, it returns a [ProcessResult]
+      // whose [exitCode] is `0` on success.
+      final isGitInstalled =
+          Process.runSync('git', ['--version']).exitCode == 0;
+      if (!isGitInstalled) {
+        throw AppException('Git is not installed');
+      }
+    } on ProcessException {
       throw AppException('Git is not installed');
     }
   }


### PR DESCRIPTION
## Summary
- handle `ProcessException` when verifying git installation
- clarify exit code behavior when checking for git

## Testing
- `dart format --output=none --set-exit-if-changed lib/src/workflows/ensure_cache.workflow.dart`
- `dart analyze`


------
https://chatgpt.com/codex/tasks/task_e_68430c26cbcc833188eb042b5ea0feb3