### PR TITLE
Add stringToBool utility tests

### DIFF
--- a/test/utils/helpers_test.dart
+++ b/test/utils/helpers_test.dart
@@ -226,4 +226,18 @@ Tools â€¢ Dart 3.2.0 (build 3.2.0-134.1.beta) â€¢ DevTools 2.27.0
     expect(formatFriendlyBytes(1024 * 1024 * 1024 * 1024 * 1024 * 1024),
         '1.00 EB');
   });
+
+  group('stringToBool', () {
+    test("'true' returns true", () {
+      expect(stringToBool('true'), isTrue);
+    });
+
+    test("'false' returns false", () {
+      expect(stringToBool('false'), isFalse);
+    });
+
+    test('invalid value returns null', () {
+      expect(stringToBool('maybe'), isNull);
+    });
+  });
 }


### PR DESCRIPTION
## Summary
- test helpers.stringToBool

## Testing
- `dart test` *(fails: `dart` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68430c2add288331beb14f5f730fbda6