### PR TITLE
Fix stack trace loss in Git validation

### DIFF
--- a/lib/src/workflows/ensure_cache.workflow.dart
+++ b/lib/src/workflows/ensure_cache.workflow.dart
@@ -87,10 +87,13 @@ class EnsureCacheWorkflow extends Workflow {
       final isGitInstalled =
           Process.runSync('git', ['--version']).exitCode == 0;
       if (!isGitInstalled) {
-        throw AppException('Git is not installed');
+        throw const AppException('Git is not installed');
       }
-    } on ProcessException {
-      throw AppException('Git is not installed');
+    } on ProcessException catch (_, stackTrace) {
+      Error.throwWithStackTrace(
+        const AppException('Git is not installed'),
+        stackTrace,
+      );
     }
   }
 


### PR DESCRIPTION
## Summary
- preserve stack trace when `_validateGit` handles `ProcessException`

## Testing
- `dart analyze`
- `dart test` *(fails: PathNotFoundException during test workflow)*

------
https://chatgpt.com/codex/tasks/task_e_684320a51e7c8331a31ddb8c7534e83d