### PR TITLE
Fix/flutter upgrade channel check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ linux/
 macos/
 ios/
 android/
+CLAUDE.md

--- a/lib/src/commands/flutter_command.dart
+++ b/lib/src/commands/flutter_command.dart
@@ -1,7 +1,12 @@
 import 'package:args/args.dart';
+import 'package:meta/meta.dart';
 
+import '../services/cache_service.dart';
+import '../services/project_service.dart';
+import '../utils/context.dart';
 import '../utils/exceptions.dart';
 import '../workflows/run_configured_flutter.workflow.dart';
+import '../workflows/validate_flutter_version.workflow.dart';
 import 'base_command.dart';
 
 /// Proxies Flutter Commands
@@ -19,7 +24,7 @@ class FlutterCommand extends BaseFvmCommand {
   @override
   Future<int> run() async {
     final args = argResults!.arguments;
-    checkIfUpgradeCommand(args);
+    checkIfUpgradeCommand(context, args);
     final runConfiguredFlutterWorkflow = RunConfiguredFlutterWorkflow(context);
 
     final result = await runConfiguredFlutterWorkflow('flutter', args: args);
@@ -28,11 +33,25 @@ class FlutterCommand extends BaseFvmCommand {
   }
 }
 
-void checkIfUpgradeCommand(List<String> args) {
-  if (args.isNotEmpty && args.first == 'upgrade') {
-    throw AppException(
-      'You should not upgrade a release version. '
-      'Please install a channel instead to upgrade it. ',
-    );
+@visibleForTesting
+void checkIfUpgradeCommand(FvmContext context, List<String> args) {
+  if (args.isEmpty || args.first != 'upgrade') return;
+
+  // Get current version - project version has priority, then global
+  final projectVersionName = context.get<ProjectService>().findVersion();
+  final versionToCheck =
+      projectVersionName ?? context.get<CacheService>().getGlobal()?.name;
+
+  if (versionToCheck != null) {
+    final version =
+        context.get<ValidateFlutterVersionWorkflow>().call(versionToCheck);
+
+    // Only block upgrade for release versions, not channels
+    if (!version.isChannel) {
+      throw AppException(
+        'You should not upgrade a release version. '
+        'Please install a channel instead to upgrade it. ',
+      );
+    }
   }
 }

--- a/test/src/commands/flutter_upgrade_check_test.dart
+++ b/test/src/commands/flutter_upgrade_check_test.dart
@@ -1,0 +1,48 @@
+import 'package:fvm/src/commands/flutter_command.dart';
+import 'package:fvm/src/models/cache_flutter_version_model.dart';
+import 'package:fvm/src/models/flutter_version_model.dart';
+import 'package:fvm/src/services/cache_service.dart';
+import 'package:fvm/src/utils/exceptions.dart';
+import 'package:test/test.dart';
+
+import '../../testing_utils.dart';
+
+void main() {
+  group('checkIfUpgradeCommand', () {
+    test('throws for release versions', () {
+      final context = TestFactory.context();
+      final cacheService = context.get<CacheService>();
+      final release = FlutterVersion.parse('2.0.0');
+      final dir = cacheService.getVersionCacheDir(release);
+      dir.createSync(recursive: true);
+      final cacheVersion = CacheFlutterVersion.fromVersion(
+        release,
+        directory: dir.path,
+      );
+      cacheService.setGlobal(cacheVersion);
+
+      expect(
+        () => checkIfUpgradeCommand(context, ['upgrade']),
+        throwsA(isA<AppException>()),
+      );
+    });
+
+    test('allows channel versions', () {
+      final context = TestFactory.context();
+      final cacheService = context.get<CacheService>();
+      final channel = FlutterVersion.parse('stable');
+      final dir = cacheService.getVersionCacheDir(channel);
+      dir.createSync(recursive: true);
+      final cacheVersion = CacheFlutterVersion.fromVersion(
+        channel,
+        directory: dir.path,
+      );
+      cacheService.setGlobal(cacheVersion);
+
+      expect(
+        () => checkIfUpgradeCommand(context, ['upgrade']),
+        returnsNormally,
+      );
+    });
+  });
+}


### PR DESCRIPTION
This pull request introduces enhancements to the `FlutterCommand` class to improve version validation during upgrade commands and adds corresponding unit tests to ensure correctness. The changes primarily focus on integrating context-based services for version checks and ensuring better test coverage.

### Enhancements to `FlutterCommand`:

* **Dependency Imports**: Added imports for `CacheService`, `ProjectService`, and `ValidateFlutterVersionWorkflow` to support context-based version validation. (`lib/src/commands/flutter_command.dart`)
* **Upgrade Command Check**: Refactored `checkIfUpgradeCommand` to use `FvmContext` for retrieving project and global versions, and added validation to block upgrades for release versions while allowing channel upgrades. (`lib/src/commands/flutter_command.dart`) [[1]](diffhunk://#diff-105b440fea8f15a9dca26c4d069def3b907748f06fcf301ee7d3860cef0f35a0L22-R27) [[2]](diffhunk://#diff-105b440fea8f15a9dca26c4d069def3b907748f06fcf301ee7d3860cef0f35a0L31-R57)

### Unit Tests for Upgrade Validation:

* **New Test Suite**: Added unit tests in `flutter_upgrade_check_test.dart` to verify the behavior of `checkIfUpgradeCommand`. Tests include scenarios for blocking upgrades of release versions and allowing upgrades for channel versions. (`test/src/commands/flutter_upgrade_check_test.dart`)