### PR TITLE
chore: apply code formatting and linter fixes

### DIFF
--- a/lib/src/models/config_model.dart
+++ b/lib/src/models/config_model.dart
@@ -174,7 +174,7 @@ class LocalAppConfig with LocalAppConfigMappable implements AppConfig {
 
   @override
   bool? updateGitIgnore;
-  
+
   @override
   bool? updateMelosSettings;
 

--- a/lib/src/workflows/update_melos_settings.workflow.dart
+++ b/lib/src/workflows/update_melos_settings.workflow.dart
@@ -89,13 +89,13 @@ class UpdateMelosSettingsWorkflow extends Workflow {
           'Would you like to configure melos.yaml to use FVM-managed Flutter SDK?',
           defaultValue: false,
         );
-        
+
         if (!confirm) {
           logger.debug('User declined to configure melos.yaml for FVM.');
-          
+
           return;
         }
-        
+
         // Add sdkPath
         yamlEditor.update(['sdkPath'], expectedSdkPath);
         melosFile.writeAsStringSync(yamlEditor.toString());
@@ -108,13 +108,13 @@ class UpdateMelosSettingsWorkflow extends Workflow {
             'Update existing FVM path in melos.yaml from "$currentSdkPath" to "$expectedSdkPath"?',
             defaultValue: false,
           );
-          
+
           if (!confirm) {
             logger.debug('User declined to update FVM path in melos.yaml.');
-            
+
             return;
           }
-          
+
           yamlEditor.update(['sdkPath'], expectedSdkPath);
           melosFile.writeAsStringSync(yamlEditor.toString());
           logger.info('Updated FVM Flutter SDK path in melos.yaml');

--- a/test/commands_test.dart
+++ b/test/commands_test.dart
@@ -194,7 +194,8 @@ void main() {
       );
 
       expect(
-        await runner.runOrThrow(['fvm', 'use', 'production', '--skip-setup', '--force']),
+        await runner.runOrThrow(
+            ['fvm', 'use', 'production', '--skip-setup', '--force']),
         ExitCode.success.code,
       );
     });

--- a/test/complete_workflow_test.dart
+++ b/test/complete_workflow_test.dart
@@ -65,7 +65,8 @@ void main() {
       expect(project.pinnedVersion, isNull);
 
       // Use the channel in the project, but skip setup
-      await testRunner.runOrThrow(['fvm', 'use', channel, '--skip-setup', '--force']);
+      await testRunner
+          .runOrThrow(['fvm', 'use', channel, '--skip-setup', '--force']);
 
       // Reload project and version information
       project = testRunner.context.get<ProjectService>().findAncestor();

--- a/test/src/workflows/resolve_project_deps_workflow_test.dart
+++ b/test/src/workflows/resolve_project_deps_workflow_test.dart
@@ -22,20 +22,21 @@ void main() {
     test('should return false when version is not setup', () async {
       final testDir = createTempDir();
       createPubspecYaml(testDir);
-      
-      final project = runner.context.get<ProjectService>().findAncestor(directory: testDir);
-      
+
+      final project =
+          runner.context.get<ProjectService>().findAncestor(directory: testDir);
+
       // Create a version that is not setup (directory doesn't exist)
       final notSetupVersion = CacheFlutterVersion.fromVersion(
         FlutterVersion.parse('3.10.0'),
         directory: '/nonexistent',
       );
-      
+
       final workflow = ResolveProjectDependenciesWorkflow(runner.context);
       final result = await workflow(project, notSetupVersion, force: false);
-      
+
       expect(result, isFalse);
-      
+
       final logger = runner.context.get<Logger>();
       expect(
         logger.outputs.any((msg) => msg.contains('Flutter SDK is not setup')),
@@ -43,38 +44,41 @@ void main() {
       );
     });
 
-    test('should return true when dart tool version matches SDK version', () async {
+    test('should return true when dart tool version matches SDK version',
+        () async {
       final testDir = createTempDir();
       createPubspecYaml(testDir);
-      
-      final project = runner.context.get<ProjectService>().findAncestor(directory: testDir);
-      
+
+      final project =
+          runner.context.get<ProjectService>().findAncestor(directory: testDir);
+
       // Create .dart_tool/version file in the PROJECT path (not testDir)
       final dartToolDir = Directory('${project.path}/.dart_tool');
       dartToolDir.createSync();
       final versionFile = File('${dartToolDir.path}/version');
       versionFile.writeAsStringSync('3.10.0');
-      
+
       // Create a properly setup version
       final versionDir = createTempDir();
       final binDir = Directory('${versionDir.path}/bin');
       binDir.createSync(recursive: true);
       File('${binDir.path}/flutter').createSync();
       File('${versionDir.path}/version').writeAsStringSync('3.10.0');
-      
+
       final setupVersion = CacheFlutterVersion.fromVersion(
         FlutterVersion.parse('3.10.0'),
         directory: versionDir.path,
       );
-      
+
       final workflow = ResolveProjectDependenciesWorkflow(runner.context);
       final result = await workflow(project, setupVersion, force: false);
-      
+
       expect(result, isTrue);
-      
+
       final logger = runner.context.get<Logger>();
       expect(
-        logger.outputs.any((msg) => msg.contains('Dart tool version matches SDK version')),
+        logger.outputs.any(
+            (msg) => msg.contains('Dart tool version matches SDK version')),
         isTrue,
       );
     });
@@ -82,29 +86,31 @@ void main() {
     test('should return true when no pubspec found', () async {
       final testDir = createTempDir();
       // Don't create pubspec.yaml
-      
-      final project = runner.context.get<ProjectService>().findAncestor(directory: testDir);
-      
+
+      final project =
+          runner.context.get<ProjectService>().findAncestor(directory: testDir);
+
       // Create a properly setup version
       final versionDir = createTempDir();
       final binDir = Directory('${versionDir.path}/bin');
       binDir.createSync(recursive: true);
       File('${binDir.path}/flutter').createSync();
       File('${versionDir.path}/version').writeAsStringSync('3.10.0');
-      
+
       final setupVersion = CacheFlutterVersion.fromVersion(
         FlutterVersion.parse('3.10.0'),
         directory: versionDir.path,
       );
-      
+
       final workflow = ResolveProjectDependenciesWorkflow(runner.context);
       final result = await workflow(project, setupVersion, force: false);
-      
+
       expect(result, isTrue);
-      
+
       final logger = runner.context.get<Logger>();
       expect(
-        logger.outputs.any((msg) => msg.contains('Skipping "pub get" because no pubspec.yaml found')),
+        logger.outputs.any((msg) =>
+            msg.contains('Skipping "pub get" because no pubspec.yaml found')),
         isTrue,
       );
     });
@@ -112,21 +118,23 @@ void main() {
     test('should handle pub get failures with user confirmation', () async {
       // This test group validates the user interaction flow when pub get fails
       // It's difficult to test without actual Flutter installed, so we test the logic paths
-      
+
       // Test case 1: User confirms
       {
         final testDir = createTempDir();
         createPubspecYaml(testDir);
-        
+
         final context = TestFactory.context(
           generators: {
             Logger: (context) => TestLogger(context)
-              ..setConfirmResponse('continue pinning this version anyway?', true),
+              ..setConfirmResponse(
+                  'continue pinning this version anyway?', true),
           },
         );
-        
-        final project = context.get<ProjectService>().findAncestor(directory: testDir);
-        
+
+        final project =
+            context.get<ProjectService>().findAncestor(directory: testDir);
+
         // Create a minimal setup version - in real test env without Flutter,
         // pub get will fail which is what we want
         final versionDir = createTempDir();
@@ -134,14 +142,14 @@ void main() {
         binDir.createSync(recursive: true);
         File('${binDir.path}/flutter').createSync();
         File('${versionDir.path}/version').writeAsStringSync('3.10.0');
-        
+
         final version = CacheFlutterVersion.fromVersion(
           FlutterVersion.parse('3.10.0'),
           directory: versionDir.path,
         );
-        
+
         final workflow = ResolveProjectDependenciesWorkflow(context);
-        
+
         try {
           final result = await workflow(project, version, force: false);
           // If pub get fails and user confirms, result should be true
@@ -156,34 +164,36 @@ void main() {
           // If running in env without Flutter, it might throw - that's ok
         }
       }
-      
+
       // Test case 2: User declines
       {
         final testDir = createTempDir();
         createPubspecYaml(testDir);
-        
+
         final context = TestFactory.context(
           generators: {
             Logger: (context) => TestLogger(context)
-              ..setConfirmResponse('continue pinning this version anyway?', false),
+              ..setConfirmResponse(
+                  'continue pinning this version anyway?', false),
           },
         );
-        
-        final project = context.get<ProjectService>().findAncestor(directory: testDir);
-        
+
+        final project =
+            context.get<ProjectService>().findAncestor(directory: testDir);
+
         final versionDir = createTempDir();
         final binDir = Directory('${versionDir.path}/bin');
         binDir.createSync(recursive: true);
         File('${binDir.path}/flutter').createSync();
         File('${versionDir.path}/version').writeAsStringSync('3.10.0');
-        
+
         final version = CacheFlutterVersion.fromVersion(
           FlutterVersion.parse('3.10.0'),
           directory: versionDir.path,
         );
-        
+
         final workflow = ResolveProjectDependenciesWorkflow(context);
-        
+
         // When user declines, it should throw AppException
         try {
           await workflow(project, version, force: false);
@@ -200,34 +210,37 @@ void main() {
     test('should skip confirmation with force flag', () async {
       final testDir = createTempDir();
       createPubspecYaml(testDir);
-      
-      final project = runner.context.get<ProjectService>().findAncestor(directory: testDir);
-      
+
+      final project =
+          runner.context.get<ProjectService>().findAncestor(directory: testDir);
+
       final versionDir = createTempDir();
       final binDir = Directory('${versionDir.path}/bin');
       binDir.createSync(recursive: true);
       File('${binDir.path}/flutter').createSync();
       File('${versionDir.path}/version').writeAsStringSync('3.10.0');
-      
+
       final version = CacheFlutterVersion.fromVersion(
         FlutterVersion.parse('3.10.0'),
         directory: versionDir.path,
       );
-      
+
       final workflow = ResolveProjectDependenciesWorkflow(runner.context);
-      
+
       try {
         final result = await workflow(project, version, force: true);
         // With force flag, when pub get fails it should return false without prompting
         if (!result) {
           final logger = runner.context.get<Logger>();
           expect(
-            logger.outputs.any((msg) => msg.contains('Force pinning due to --force flag')),
+            logger.outputs.any(
+                (msg) => msg.contains('Force pinning due to --force flag')),
             isTrue,
           );
           // Should not see confirmation prompt
           expect(
-            logger.outputs.any((msg) => msg.contains('Would you like to continue pinning this version anyway?')),
+            logger.outputs.any((msg) => msg.contains(
+                'Would you like to continue pinning this version anyway?')),
             isFalse,
           );
         }

--- a/test/src/workflows/update_melos_settings.workflow_test.dart
+++ b/test/src/workflows/update_melos_settings.workflow_test.dart
@@ -45,10 +45,11 @@ packages:
             ..setConfirmResponse('configure melos.yaml', false),
         },
       );
-      
+
       final customRunner = TestCommandRunner(context);
-      final project =
-          customRunner.context.get<ProjectService>().findAncestor(directory: testDir);
+      final project = customRunner.context
+          .get<ProjectService>()
+          .findAncestor(directory: testDir);
       final workflow = UpdateMelosSettingsWorkflow(customRunner.context);
 
       // Run workflow
@@ -57,11 +58,12 @@ packages:
       // Verify melos.yaml was NOT updated (user declined)
       final newContent = melosFile.readAsStringSync();
       expect(newContent, originalContent);
-      
+
       // Verify we can see the detection message
       final logger = customRunner.context.get<Logger>();
       expect(
-        logger.outputs.any((msg) => msg.contains('Detected melos.yaml without FVM configuration')),
+        logger.outputs.any((msg) =>
+            msg.contains('Detected melos.yaml without FVM configuration')),
         isTrue,
       );
     });
@@ -103,7 +105,7 @@ sdkPath: /any/existing/path
       // Create test project in a subdirectory
       final subDir = Directory(p.join(testDir.path, 'subproject'));
       subDir.createSync();
-      
+
       createPubspecYaml(subDir);
       createProjectConfig(
         ProjectConfig(flutter: '3.10.0'),
@@ -127,10 +129,11 @@ packages:
             ..setConfirmResponse('configure melos.yaml', false),
         },
       );
-      
+
       final customRunner = TestCommandRunner(context);
-      final project =
-          customRunner.context.get<ProjectService>().findAncestor(directory: subDir);
+      final project = customRunner.context
+          .get<ProjectService>()
+          .findAncestor(directory: subDir);
       final workflow = UpdateMelosSettingsWorkflow(customRunner.context);
 
       // Run workflow
@@ -141,7 +144,8 @@ packages:
       expect(newContent, originalContent);
     });
 
-    test('should not modify melos.yaml with existing non-FVM sdkPath', () async {
+    test('should not modify melos.yaml with existing non-FVM sdkPath',
+        () async {
       final testDir = createTempDir();
       // Create test project
       createPubspecYaml(testDir);
@@ -178,11 +182,11 @@ sdkPath: /usr/local/flutter
 
     test('should calculate correct relative path for nested melos', () async {
       final testDir = createTempDir();
-      
+
       // Create a nested structure
       final nestedDir = Directory(p.join(testDir.path, 'apps', 'mobile'));
       nestedDir.createSync(recursive: true);
-      
+
       createPubspecYaml(nestedDir);
       createProjectConfig(
         ProjectConfig(flutter: '3.10.0'),
@@ -206,10 +210,11 @@ packages:
             ..setConfirmResponse('configure melos.yaml', false),
         },
       );
-      
+
       final customRunner = TestCommandRunner(context);
-      final project =
-          customRunner.context.get<ProjectService>().findAncestor(directory: nestedDir);
+      final project = customRunner.context
+          .get<ProjectService>()
+          .findAncestor(directory: nestedDir);
       final workflow = UpdateMelosSettingsWorkflow(customRunner.context);
 
       // Run workflow
@@ -283,7 +288,8 @@ packages:
       expect(newContent, originalContent);
     });
 
-    test('should detect existing FVM path but not update without confirmation', () async {
+    test('should detect existing FVM path but not update without confirmation',
+        () async {
       final testDir = createTempDir();
       // Create test project
       createPubspecYaml(testDir);
@@ -310,10 +316,11 @@ sdkPath: .fvm/versions/3.10.0
             ..setConfirmResponse('Update existing FVM path', false),
         },
       );
-      
+
       final customRunner = TestCommandRunner(context);
-      final project =
-          customRunner.context.get<ProjectService>().findAncestor(directory: testDir);
+      final project = customRunner.context
+          .get<ProjectService>()
+          .findAncestor(directory: testDir);
       final workflow = UpdateMelosSettingsWorkflow(customRunner.context);
 
       // Run workflow
@@ -356,7 +363,8 @@ packages:
     });
 
     group('with simulated user input', () {
-      test('should update melos.yaml when user confirms (simulated Yes)', () async {
+      test('should update melos.yaml when user confirms (simulated Yes)',
+          () async {
         final testDir = createTempDir();
         createPubspecYaml(testDir);
         createProjectConfig(
@@ -379,29 +387,33 @@ packages:
               ..setConfirmResponse('configure melos.yaml', true),
           },
         );
-        
+
         final customRunner = TestCommandRunner(context);
-        final project = customRunner.context.get<ProjectService>().findAncestor(directory: testDir);
+        final project = customRunner.context
+            .get<ProjectService>()
+            .findAncestor(directory: testDir);
         final workflow = UpdateMelosSettingsWorkflow(customRunner.context);
-        
+
         // Run workflow
         await workflow(project);
-        
+
         // Verify melos.yaml was updated
         final melosContent = melosFile.readAsStringSync();
         final yaml = loadYaml(melosContent) as Map;
-        
+
         expect(yaml['sdkPath'], isNotNull);
         expect(yaml['sdkPath'], '.fvm/flutter_sdk');
-        
+
         // Verify logged messages
         final logger = customRunner.context.get<Logger>();
         expect(
-          logger.outputs.any((msg) => msg.contains('Detected melos.yaml without FVM configuration')),
+          logger.outputs.any((msg) =>
+              msg.contains('Detected melos.yaml without FVM configuration')),
           isTrue,
         );
         expect(
-          logger.outputs.any((msg) => msg.contains('Added FVM Flutter SDK path to melos.yaml')),
+          logger.outputs.any((msg) =>
+              msg.contains('Added FVM Flutter SDK path to melos.yaml')),
           isTrue,
         );
       });
@@ -430,24 +442,27 @@ sdkPath: .fvm/versions/3.10.0
               ..setConfirmResponse('Update existing FVM path', true),
           },
         );
-        
+
         final customRunner = TestCommandRunner(context);
-        final project = customRunner.context.get<ProjectService>().findAncestor(directory: testDir);
+        final project = customRunner.context
+            .get<ProjectService>()
+            .findAncestor(directory: testDir);
         final workflow = UpdateMelosSettingsWorkflow(customRunner.context);
-        
+
         // Run workflow
         await workflow(project);
-        
+
         // Verify melos.yaml was updated
         final melosContent = melosFile.readAsStringSync();
         final yaml = loadYaml(melosContent) as Map;
-        
+
         expect(yaml['sdkPath'], '.fvm/flutter_sdk');
-        
+
         // Verify logged messages
         final logger = customRunner.context.get<Logger>();
         expect(
-          logger.outputs.any((msg) => msg.contains('Updated FVM Flutter SDK path in melos.yaml')),
+          logger.outputs.any((msg) =>
+              msg.contains('Updated FVM Flutter SDK path in melos.yaml')),
           isTrue,
         );
       });
@@ -475,18 +490,19 @@ packages:
               ..setConfirmResponse('configure melos.yaml', false),
           },
         );
-        
+
         final customRunner = TestCommandRunner(context);
-        final project =
-            customRunner.context.get<ProjectService>().findAncestor(directory: testDir);
+        final project = customRunner.context
+            .get<ProjectService>()
+            .findAncestor(directory: testDir);
         final workflow = UpdateMelosSettingsWorkflow(customRunner.context);
         final logger = customRunner.context.get<Logger>();
-        
+
         // Clear previous outputs
         logger.outputs.clear();
-        
+
         await workflow(project);
-        
+
         // Verify that we can see all the logged outputs
         expect(logger.outputs.length, greaterThan(0));
         expect(
@@ -501,6 +517,5 @@ packages:
         );
       });
     });
-
   });
 }


### PR DESCRIPTION
This pull request primarily focuses on improving code readability by reformatting long lines in test files across multiple workflows and contexts. The changes involve breaking down expressions into multiple lines and ensuring consistent formatting for better maintainability.

### Code readability improvements:

* **Reformatted long expressions in test assertions and method calls**:
  - Updated `runner.runOrThrow` calls in `test/commands_test.dart` and `test/complete_workflow_test.dart` to span multiple lines for improved readability. [[1]](diffhunk://#diff-099824cf45f685ecf4df738a1bb8226ced9265fd71ed3b034d9bfadb4e1b04aaL197-R198) [[2]](diffhunk://#diff-8ec8940fe4f117a2b2a884a5eaa96616eb962d0937e83236099cb1f47b5ad390L68-R69)
  - Reformatted `runner.context.get<ProjectService>().findAncestor` calls in `test/src/workflows/resolve_project_deps_workflow_test.dart` and `test/src/workflows/update_melos_settings.workflow_test.dart` to split across multiple lines. [[1]](diffhunk://#diff-e036a8d6cb7d3fda42ec0466743d3a41bc63e55b92d6d5c95bdb8cc5da64628eL26-R27) [[2]](diffhunk://#diff-4911b41be876875d4761fa5ae80583f3477f0fa6253acd2ebe09d81fa41b2567L50-R52) [[3]](diffhunk://#diff-4911b41be876875d4761fa5ae80583f3477f0fa6253acd2ebe09d81fa41b2567L132-R136)

* **Improved readability of test expectations**:
  - Adjusted `logger.outputs.any` assertions to span multiple lines for better clarity in `test/src/workflows/resolve_project_deps_workflow_test.dart` and `test/src/workflows/update_melos_settings.workflow_test.dart`. [[1]](diffhunk://#diff-e036a8d6cb7d3fda42ec0466743d3a41bc63e55b92d6d5c95bdb8cc5da64628eL77-R81) [[2]](diffhunk://#diff-4911b41be876875d4761fa5ae80583f3477f0fa6253acd2ebe09d81fa41b2567L64-R66) [[3]](diffhunk://#diff-4911b41be876875d4761fa5ae80583f3477f0fa6253acd2ebe09d81fa41b2567L450-R465)

* **Reformatted test descriptions for clarity**:
  - Updated long test descriptions to span multiple lines in `test/src/workflows/resolve_project_deps_workflow_test.dart` and `test/src/workflows/update_melos_settings.workflow_test.dart`. [[1]](diffhunk://#diff-e036a8d6cb7d3fda42ec0466743d3a41bc63e55b92d6d5c95bdb8cc5da64628eL46-R53) [[2]](diffhunk://#diff-4911b41be876875d4761fa5ae80583f3477f0fa6253acd2ebe09d81fa41b2567L144-R148) [[3]](diffhunk://#diff-4911b41be876875d4761fa5ae80583f3477f0fa6253acd2ebe09d81fa41b2567L286-R292)

These formatting changes enhance the readability and maintainability of the test code without altering its functionality.- Applied dart format to ensure consistent code style
