### PR TITLE
Docs: Fix quickstart

### DIFF
--- a/docs/pages/documentation/getting-started/index.md
+++ b/docs/pages/documentation/getting-started/index.md
@@ -11,6 +11,7 @@ FVM helps with the need for consistent app builds by referencing the Flutter SDK
 
 ```bash
 # Install FVM
+brew tap leoafarias/fvm
 brew install fvm
 
 # Set Flutter version for a project


### PR DESCRIPTION
Quickstart commands missed a `brew tab`, leading to failed installation. Correct command is in [later pages](https://fvm.app/documentation/getting-started/installation) of docs, but adding it to quickstart makes a lot of sense for first-time devs.