### PR TITLE
fix: correct install script URLs in documentation (#872)

### DIFF
--- a/docs/pages/documentation/getting-started/installation.mdx
+++ b/docs/pages/documentation/getting-started/installation.mdx
@@ -24,13 +24,13 @@ You can download the standalone packages from the GitHub repo [here](https://git
 Install the latest version:
 
 ```bash
-curl -fsSL https://fvm.app/install | bash
+curl -fsSL https://fvm.app/install.sh | bash
 ```
 
 Install a specific version:
 
 ```bash
-curl -fsSL https://fvm.app/install | bash -s 3.2.1
+curl -fsSL https://fvm.app/install.sh | bash -s 3.2.1
 ```
 
 ## Homebrew
@@ -74,13 +74,13 @@ choco uninstall fvm
 Install the latest version:
 
 ```bash
-curl -fsSL https://fvm.app/install | bash
+curl -fsSL https://fvm.app/install.sh | bash
 ```
 
 Install a specific version:
 
 ```bash
-curl -fsSL https://fvm.app/install | bash -s 3.2.1
+curl -fsSL https://fvm.app/install.sh | bash -s 3.2.1
 ```
 
 ## Homebrew
@@ -127,8 +127,8 @@ dart pub global deactivate fvm
 
 The install script (`install.sh`) supports several options:
 
-- **Latest version**: `curl -fsSL https://fvm.app/install | bash`
-- **Specific version**: `curl -fsSL https://fvm.app/install | bash -s 3.2.1`
+- **Latest version**: `curl -fsSL https://fvm.app/install.sh | bash`
+- **Specific version**: `curl -fsSL https://fvm.app/install.sh | bash -s 3.2.1`
 - **Container/CI support**: Set `FVM_ALLOW_ROOT=true` for Docker/CI environments
 - **Help**: `./install.sh --help`
 - **Version info**: `./install.sh --version`

--- a/docs/public/install.sh
+++ b/docs/public/install.sh
@@ -2,8 +2,8 @@
 # FVM Installer - Install/Uninstall Flutter Version Management
 #
 # Usage:
-#   curl -fsSL https://fvm.app/install | bash
-#   curl -fsSL https://fvm.app/install | bash -s 3.2.1
+#   curl -fsSL https://fvm.app/install.sh | bash
+#   curl -fsSL https://fvm.app/install.sh | bash -s 3.2.1
 #   ./install.sh [OPTIONS] [VERSION]
 #
 # Examples:
@@ -62,8 +62,8 @@ FVM Installer v${SCRIPT_VERSION}
 Install/Uninstall Flutter Version Management (FVM) on Linux/macOS
 
 USAGE:
-    curl -fsSL https://fvm.app/install | bash
-    curl -fsSL https://fvm.app/install | bash -s [VERSION]
+    curl -fsSL https://fvm.app/install.sh | bash
+    curl -fsSL https://fvm.app/install.sh | bash -s [VERSION]
     ./install.sh [OPTIONS] [VERSION]
 
 OPTIONS:
@@ -77,10 +77,10 @@ ARGUMENTS:
 
 EXAMPLES:
     # Install latest version
-    curl -fsSL https://fvm.app/install | bash
-    
+    curl -fsSL https://fvm.app/install.sh | bash
+
     # Install specific version
-    curl -fsSL https://fvm.app/install | bash -s 3.2.1
+    curl -fsSL https://fvm.app/install.sh | bash -s 3.2.1
     
     # Uninstall FVM
     ./install.sh --uninstall

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -16,10 +16,10 @@ The main FVM installation script for Linux/macOS that:
 Usage:
 ```bash
 # Install latest version
-curl -fsSL https://fvm.app/install | bash
+curl -fsSL https://fvm.app/install.sh | bash
 
 # Install specific version
-curl -fsSL https://fvm.app/install | bash -s 3.2.1
+curl -fsSL https://fvm.app/install.sh | bash -s 3.2.1
 
 # Uninstall FVM
 ./install.sh --uninstall

--- a/scripts/install.md
+++ b/scripts/install.md
@@ -5,13 +5,13 @@
 ### Quick Install (Latest Version)
 
 ```bash
-curl -fsSL https://fvm.app/install | bash
+curl -fsSL https://fvm.app/install.sh | bash
 ```
 
 ### Install Specific Version
 
 ```bash
-curl -fsSL https://fvm.app/install | bash -s 3.2.1
+curl -fsSL https://fvm.app/install.sh | bash -s 3.2.1
 ```
 
 ### Container/CI Installation
@@ -20,13 +20,13 @@ For Docker, Podman, or CI environments:
 
 ```bash
 export FVM_ALLOW_ROOT=true
-curl -fsSL https://fvm.app/install | bash
+curl -fsSL https://fvm.app/install.sh | bash
 ```
 
 ### Uninstall
 
 ```bash
-curl -fsSL https://fvm.app/install | bash -s -- --uninstall
+curl -fsSL https://fvm.app/install.sh | bash -s -- --uninstall
 ```
 
 ## Install on Windows

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,8 +2,8 @@
 # FVM Installer - Install/Uninstall Flutter Version Management
 #
 # Usage:
-#   curl -fsSL https://fvm.app/install | bash
-#   curl -fsSL https://fvm.app/install | bash -s 3.2.1
+#   curl -fsSL https://fvm.app/install.sh | bash
+#   curl -fsSL https://fvm.app/install.sh | bash -s 3.2.1
 #   ./install.sh [OPTIONS] [VERSION]
 #
 # Examples:
@@ -62,8 +62,8 @@ FVM Installer v${SCRIPT_VERSION}
 Install/Uninstall Flutter Version Management (FVM) on Linux/macOS
 
 USAGE:
-    curl -fsSL https://fvm.app/install | bash
-    curl -fsSL https://fvm.app/install | bash -s [VERSION]
+    curl -fsSL https://fvm.app/install.sh | bash
+    curl -fsSL https://fvm.app/install.sh | bash -s [VERSION]
     ./install.sh [OPTIONS] [VERSION]
 
 OPTIONS:
@@ -77,10 +77,10 @@ ARGUMENTS:
 
 EXAMPLES:
     # Install latest version
-    curl -fsSL https://fvm.app/install | bash
-    
+    curl -fsSL https://fvm.app/install.sh | bash
+
     # Install specific version
-    curl -fsSL https://fvm.app/install | bash -s 3.2.1
+    curl -fsSL https://fvm.app/install.sh | bash -s 3.2.1
     
     # Uninstall FVM
     ./install.sh --uninstall


### PR DESCRIPTION
## Description

Fixes the broken install script URL issue reported in #872 by correcting the documentation to use the working URL `https://fvm.app/install.sh` instead of the broken `https://fvm.app/install`.

## Problem

In commit a3da7318cdd5f4612f79c37ce0a2d2df4735623f, the documentation was updated to reference `https://fvm.app/install`, but this URL returns a 404 error because:

- ❌ `https://fvm.app/install` returns 404 error
- ✅ `https://fvm.app/install.sh` works correctly
- ❌ Users following official documentation cannot install FVM

## Solution

Corrected all documentation and script references to use the working URL `https://fvm.app/install.sh`:

- Updated `docs/pages/documentation/getting-started/installation.mdx`
- Updated `scripts/install.sh` (help text and comments)
- Updated `docs/public/install.sh` (to keep in sync)
- Updated `scripts/README.md`
- Updated `scripts/install.md`

## Changes

- ✅ All references now use `https://fvm.app/install.sh`
- ✅ Documentation matches the working URL
- ✅ Install script help text is consistent
- ✅ No infrastructure changes needed
- ✅ Simple, focused fix

## Testing

- ✅ `https://fvm.app/install.sh` confirmed working
- ✅ All script files are in sync
- ✅ Documentation is consistent across all files
- ✅ Users can now follow the documentation successfully

## Impact

- Fixes primary installation method for macOS/Linux users
- Resolves discrepancy between documentation and working URLs
- No infrastructure changes required
- Immediate fix that works with current deployment
- Follows KISS principle - simple documentation fix

Closes #872

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author