### PR TITLE
fix: replace incorrect Homebrew instructions in Linux installation tab

### DIFF
--- a/docs/pages/documentation/getting-started/installation.mdx
+++ b/docs/pages/documentation/getting-started/installation.mdx
@@ -83,21 +83,9 @@ Install a specific version:
 curl -fsSL https://fvm.app/install.sh | bash -s 3.2.1
 ```
 
-## Homebrew
+## Alternative Installation
 
-Install:
-
-```bash
-brew tap leoafarias/fvm
-brew install fvm
-```
-
-Uninstall:
-
-```bash
-brew uninstall fvm
-brew untap leoafarias/fvm
-```
+For alternative installation methods, see the [GitHub Releases](https://github.com/leoafarias/fvm/releases/latest) page.
 
 </Tabs.Tab>
 


### PR DESCRIPTION
## Problem

Fixes #822 - The Linux tab in the installation documentation was incorrectly displaying macOS Homebrew installation instructions instead of Linux-specific commands.

## Solution

Replaced the inappropriate Homebrew content with a simple reference to GitHub releases for alternative installation methods, while keeping the install script as the recommended approach.

## Changes

- ✅ **Removed**: Homebrew installation instructions from Linux tab
- ✅ **Added**: Simple reference to GitHub releases for alternatives
- ✅ **Kept**: Install script as recommended method (already works perfectly for Linux)

## YAGNI/KISS/DRY Compliance

This fix follows the project's principles:

- **YAGNI**: Doesn't add unnecessary package manager instructions
- **KISS**: Simple solution that leverages existing working install script
- **DRY**: Avoids duplicating functionality already provided by install script

## Testing

The install script already handles:
- ✅ Linux architecture detection (x64, arm64, etc.)
- ✅ Automatic binary download and installation
- ✅ PATH configuration
- ✅ Uninstall functionality

## Impact

- **High user impact**: Linux users now see appropriate installation instructions
- **No breaking changes**: Existing working methods preserved
- **Minimal maintenance**: No hardcoded versions or complex instructions to maintain

Linux users can now follow clear, platform-appropriate installation steps instead of being confused by macOS-specific Homebrew commands.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author