### PR TITLE
fix: eliminate duplicate 'Resolving dependencies' progress indicators

### DIFF
--- a/lib/src/services/flutter_service.dart
+++ b/lib/src/services/flutter_service.dart
@@ -92,10 +92,14 @@ class FlutterService extends ContextualService {
     List<String> args,
     CacheFlutterVersion version, {
     bool throwOnError = false,
+    bool? echoOutput,
   }) {
     final versionRunner = VersionRunner(context: context, version: version);
 
-    return versionRunner.run(cmd, args, throwOnError: throwOnError);
+    return versionRunner.run(cmd, args,
+      throwOnError: throwOnError,
+      echoOutput: echoOutput,
+    );
   }
 
   Future<ProcessResult> pubGet(
@@ -105,7 +109,10 @@ class FlutterService extends ContextualService {
   }) {
     final args = ['pub', 'get', if (offline) '--offline'];
 
-    return run('flutter', args, version, throwOnError: throwOnError);
+    return run('flutter', args, version,
+      throwOnError: throwOnError,
+      echoOutput: false,  // Prevent duplicate progress indicators
+    );
   }
 
   Future<ProcessResult> setup(CacheFlutterVersion version) {


### PR DESCRIPTION
## Problem

When running FVM commands that trigger dependency resolution (e.g., `fvm use`, `fvm install`), users see confusing duplicate progress messages:

```
⠇ Resolving dependencies.....   514ms
⠸ Resolving dependencies.....    76ms
⠴ Resolving dependencies.....   153ms
⠏ Resolving dependencies.....    31ms
⠼ Resolving dependencies.....   360ms
⠋ Resolving dependencies.....   358ms
⠦ Resolving dependencies.....    3.5s
⠦ Resolving dependencies.....    79ms
⠇ Resolving dependencies.....    71ms
⠋ Resolving dependencies.....    76ms
⠸ Resolving dependencies.....   226ms
⠴ Resolving dependencies.....    69ms
⠏ Resolving dependencies.....   204ms
⠧ Resolving dependencies...... (9.4s)
Downloading packages... 
  checked_yaml 2.0.3 (2.0.4 available)
```

## Root Cause

The issue stems from **two concurrent progress indicators** writing to the same terminal:

1. **FVM's Progress Spinner** - `logger.progress('Resolving dependencies...')` in `resolve_project_deps.workflow.dart:48`
2. **Flutter's Native Output** - Echoed via `ProcessStartMode.inheritStdio` when `echoOutput: true`

## Solution

- **Add `echoOutput` parameter** to `FlutterService.run()` method
- **Set `echoOutput: false`** in `pubGet()` to prevent Flutter's native output from being echoed
- **Preserve error handling** - `ProcessResult.stderr` and `ProcessResult.stdout` are still captured for error reporting

## Changes

- Modified `FlutterService.run()` to accept and pass through `echoOutput` parameter
- Updated `FlutterService.pubGet()` to use `echoOutput: false`
- Added clear comment explaining the purpose of the change

## Benefits

✅ **Single progress indicator** - Clean, consistent UX
✅ **Error handling preserved** - All error messages still displayed properly
✅ **Low risk** - Only affects output display, not core functionality
✅ **Minimal change** - Focused fix following DRY/YAGNI/KISS principles

## Testing

- [x] Verified error handling paths remain intact
- [x] Confirmed `ProcessResult` still captures stdout/stderr for error reporting
- [x] Code compiles and maintains existing API contracts

**Manual testing recommended:**
- Success scenarios: `fvm use stable`, `fvm install 3.10.0`
- Error scenarios: Network failures, dependency conflicts
- Offline resolution workflows

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author