### PR TITLE
fix: correct broken link in `feature_request.md` and `faq.md`

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,7 +6,7 @@ labels: enhancement
 assignees: ""
 ---
 
-## Before creating a feature request make sure the suggestion fit within our [principles](https://fvm.app/docs/#principles)
+## Before creating a feature request make sure the suggestion fit within our [principles](https://fvm.app/#principles)
 
 **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]

--- a/docs/pages/documentation/getting-started/faq.md
+++ b/docs/pages/documentation/getting-started/faq.md
@@ -7,7 +7,7 @@ title: FAQ
 
 ## Upgrade Flutter Channel
 
-As described in our [Principles](../getting-started/#principles), FVM does not override standard Flutter behavior. Therefore, to upgrade a channel, you will have to use the standard `flutter upgrade`. You can find more about it in the [Running Flutter](../guides/running-flutter) section.
+As described in our [Principles](https://fvm.app/#principles), FVM does not override standard Flutter behavior. Therefore, to upgrade a channel, you will have to use the standard `flutter upgrade`. You can find more about it in the [Running Flutter](../guides/running-flutter) section.
 
 ---
 


### PR DESCRIPTION
This PR fixes broken links to the FVM Principles web page in the following files:

- .github/ISSUE_TEMPLATE/feature_request.md
- docs/pages/documentation/getting-started/faq.md