### PR TITLE
fix: Handle fork install fallback correctly

### DIFF
--- a/lib/src/workflows/ensure_cache.workflow.dart
+++ b/lib/src/workflows/ensure_cache.workflow.dart
@@ -161,14 +161,15 @@ class EnsureCacheWorkflow extends Workflow {
 
     bool useGitCache = context.gitCache;
 
-    if (useGitCache) {
+    // Only update local mirror if not a fork and git cache is enabled
+    if (useGitCache && !version.fromFork) {
       try {
         await gitService.updateLocalMirror();
       } on Exception {
         logger.warn(
           'Failed to setup local cache. Falling back to git clone.',
         );
-        rethrow;
+        // Do not rethrow, allow to fallback to clone
       }
     }
 


### PR DESCRIPTION
>
> Resolves issue where a failure during the local cache update for the main Flutter repo would incorrectly terminate the installation process for a custom fork.
>
> The fix implements two changes:
> 1.  The local cache mirror is no longer updated when installing a forked version, as it's an unnecessary step.
> 2.  The exception handling within the cache workflow is corrected to prevent a 'rethrow' on failure, allowing the process to correctly fall back to a direct git clone as intended.
>
> This makes the fork installation process more robust and resilient to network issues with the main Flutter repository.
>
> Fixes #886