### PR TITLE
Docs: Update getting started links

### DIFF
--- a/docs/pages/documentation/getting-started/index.md
+++ b/docs/pages/documentation/getting-started/index.md
@@ -31,6 +31,6 @@ fvm flutter doctor
 
 ## Next Steps
 
-1. [Install FVM](../getting-started/installation) on your system
-2. [Configure](../getting-started/configuration) your first project
-3. Check the [FAQ](../getting-started/faq) for common questions
+1. [Install FVM](./getting-started/installation) on your system
+2. [Configure](./getting-started/configuration) your first project
+3. Check the [FAQ](./getting-started/faq) for common questions

--- a/docs/pages/documentation/getting-started/index.md
+++ b/docs/pages/documentation/getting-started/index.md
@@ -31,6 +31,6 @@ fvm flutter doctor
 
 ## Next Steps
 
-1. [Install FVM](./installation) on your system
-2. [Configure](./configuration) your first project
-3. Check the [FAQ](./faq) for common questions
+1. [Install FVM](../getting-started/installation) on your system
+2. [Configure](../getting-started/configuration) your first project
+3. Check the [FAQ](../getting-started/faq) for common questions


### PR DESCRIPTION
The links in the "Next Steps" section of the getting started page have been updated to correctly point to the installation, configuration, and FAQ pages.