### PR TITLE
fix: resolve private repository authentication and duplicate progress indicators

### DIFF
--- a/lib/src/services/flutter_service.dart
+++ b/lib/src/services/flutter_service.dart
@@ -96,7 +96,9 @@ class FlutterService extends ContextualService {
   }) {
     final versionRunner = VersionRunner(context: context, version: version);
 
-    return versionRunner.run(cmd, args,
+    return versionRunner.run(
+      cmd,
+      args,
       throwOnError: throwOnError,
       echoOutput: echoOutput,
     );
@@ -109,9 +111,13 @@ class FlutterService extends ContextualService {
   }) {
     final args = ['pub', 'get', if (offline) '--offline'];
 
-    return run('flutter', args, version,
+    // For offline mode, we can safely suppress output
+    // For online mode, we need to allow stdio inheritance for authentication prompts
+    return run(
+      'flutter', args, version,
       throwOnError: throwOnError,
-      echoOutput: false,  // Prevent duplicate progress indicators
+      echoOutput:
+          !offline, // Allow stdio inheritance for authentication when online
     );
   }
 

--- a/lib/src/workflows/resolve_project_deps.workflow.dart
+++ b/lib/src/workflows/resolve_project_deps.workflow.dart
@@ -45,8 +45,6 @@ class ResolveProjectDependenciesWorkflow extends Workflow {
       return true;
     }
 
-    final progress = logger.progress('Resolving dependencies...');
-
     // Try to resolve offline
     final pubGetOfflineResults = await flutterService.pubGet(
       version,
@@ -54,22 +52,21 @@ class ResolveProjectDependenciesWorkflow extends Workflow {
     );
 
     if (pubGetOfflineResults.isSuccess) {
-      progress.complete('Dependencies resolved offline.');
+      logger.info('Dependencies resolved offline.');
 
       return true;
     }
 
-    progress.update('Trying to resolve dependencies...');
-
+    logger.info('Trying to resolve dependencies online...');
     final pubGetResults = await flutterService.pubGet(version);
 
     if (pubGetResults.isSuccess) {
-      progress.complete('Dependencies resolved.');
+      logger.info('Dependencies resolved.');
 
       return true;
     }
 
-    progress.fail('Could not resolve dependencies.');
+    logger.err('Could not resolve dependencies.');
     logger
       ..info()
       ..err(pubGetResults.stderr.toString());


### PR DESCRIPTION
## Summary
- Fix FVM hanging when accessing private repositories during dependency resolution
- Maintain fix for duplicate progress indicators while allowing authentication prompts
- Replace spinner-based progress with simple log messages for cleaner output

## Problem
FVM was hanging indefinitely when trying to resolve dependencies for projects with private Git repositories. The issue occurred because:

1. `pubGet()` was running with `echoOutput: false` for all operations
2. This prevented stdio inheritance, making authentication prompts invisible
3. The process would wait indefinitely for user input that never came

## Solution
- Allow stdio inheritance (`echoOutput: true`) for online pub get operations to enable authentication prompts
- Suppress stdio inheritance (`echoOutput: false`) for offline operations to prevent duplicate progress indicators
- Replace spinner-based progress indicators with simple log messages to avoid conflicts with Flutter's native progress output

## Changes
- **flutter_service.dart**: Modified `pubGet()` to conditionally enable stdio inheritance based on offline mode
- **resolve_project_deps.workflow.dart**: Removed custom progress indicators and replaced with simple log messages

## Fixes
- Resolves #831: FVM no longer hangs when accessing private repositories
- Maintains fix for duplicate progress indicators from #882

## Test Plan
- [x] Verified offline operations still suppress duplicate progress indicators
- [x] Confirmed online operations allow stdio inheritance for authentication
- [x] Tested with public repositories to ensure no regression
- [x] Lint and analysis checks pass