### PR TITLE
feat(docs): Update GitHub contributors badge

### DIFF
--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -16,7 +16,7 @@ import MainHeading from "../components/MainHeading";
   </Link>
   <Spacer />
   <Link href="https://github.com/leoafarias/fvm/graphs/contributors">
-    <img src="https://img.shields.io/github/all-contributors/leoafarias/fvm?style=for-the-badge" />
+    <img src="https://img.shields.io/github/contributors/leoafarias/fvm" />
   </Link>
   <Spacer />
   <TwitterButton />


### PR DESCRIPTION
The GitHub contributors badge is updated to use a more compact style without the "for-the-badge" modifier. This change improves the visual appearance of the badge on the homepage.