### PR TITLE
Add brew tap to quick start instructions

### DIFF
--- a/docs/pages/documentation/getting-started/index.md
+++ b/docs/pages/documentation/getting-started/index.md
@@ -11,6 +11,7 @@ FVM helps with the need for consistent app builds by referencing the Flutter SDK
 
 ```bash
 # Install FVM
+brew tap leoafarias/fvm
 brew install fvm
 
 # Set Flutter version for a project


### PR DESCRIPTION
`brew install fvm` will not find fvm until the casket has been tapped.