### PR TITLE
feat: enable single-file executable distribution

### DIFF
--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -19,6 +19,9 @@ void main(List<String> args) {
   pkg.githubRepo.value = '$owner/$_packageName';
   pkg.homebrewRepo.value = '$owner/homebrew-$_packageName';
   pkg.githubBearerToken.value = Platform.environment['GITHUB_TOKEN'];
+  
+  // Enable standalone executables for all platforms
+  pkg.standaloneName.value = _packageName;
 
   if (args.contains('--versioned-formula')) {
     pkg.homebrewCreateVersionedFormula.value = true;


### PR DESCRIPTION
## Summary
- Enables cli_pkg to generate standalone executables for all platforms
- Adds the necessary configuration for single-file .exe distribution required by WinGet
- Minimal change: adds `pkg.standaloneName.value = _packageName` to grind.dart

## Problem Addressed
Fixes #891 - WinGet requires portable applications to be .exe files, not .bat files. This enables the packaging infrastructure needed for WinGet distribution.

## Current Upstream Status
⚠️ **Note**: This change enables the standalone executable configuration, but full functionality depends on upstream cli_pkg support for standalone executables, tracked in [google/dart_cli_pkg#67](https://github.com/google/dart_cli_pkg/issues/67).

**Current situation:**
- The cli_pkg maintainer has been hesitant to add unsigned executable support due to Windows security warnings
- However, recent discussion shows the same author who opened our issue #891 is actively advocating for this feature
- A PR is in progress: [google/dart_cli_pkg#182](https://github.com/google/dart_cli_pkg/pull/182) 
- The maintainer has agreed to an "off-by-default option" for unsigned executables

**Why this change is still valuable:**
- Sets up the correct configuration for when upstream support lands
- Dev builds already work with current cli_pkg: `dart run grinder pkg-standalone-dev` ✅
- Prepares FVM for WinGet distribution once cli_pkg support is complete

## Technical Details
- Enables `pkg-standalone-*` grinder tasks for all platforms
- Configures cli_pkg to generate self-contained executables without external Dart runtime dependency
- Successfully tested with `pkg-standalone-dev` which works with current limitations

## Test Plan
- [x] Verified dev build works: `dart run grinder pkg-standalone-dev`
- [x] Confirmed executable runs: `./build/fvm --version`
- [x] Validated standalone functionality with current cli_pkg version
- [ ] Full production build testing pending upstream cli_pkg improvements

## Related Upstream Issues
- **Core issue**: Standalone executable support [google/dart_cli_pkg#67](https://github.com/google/dart_cli_pkg/issues/67)
- **Active PR**: Add native exe option [google/dart_cli_pkg#182](https://github.com/google/dart_cli_pkg/pull/182)
- **WinGet discussion**: [google/dart_cli_pkg#135](https://github.com/google/dart_cli_pkg/issues/135)