### PR TITLE
fix: resolve lint warnings for unused assignments and prefer-iterable-of

### DIFF
--- a/lib/src/commands/global_command.dart
+++ b/lib/src/commands/global_command.dart
@@ -69,10 +69,10 @@ class GlobalCommand extends BaseFvmCommand {
     if (argResults!.rest.isEmpty) {
       final versions = await cacheService.getAllVersions();
       version = logger.cacheVersionSelector(versions);
+    } else {
+      // Get first arg if it was not empty
+      version = argResults!.rest[0];
     }
-
-    // Get first arg if it was not empty
-    version ??= argResults!.rest[0];
 
     final flutterVersion = validateFlutterVersion(version);
 

--- a/lib/src/commands/remove_command.dart
+++ b/lib/src/commands/remove_command.dart
@@ -54,9 +54,9 @@ class RemoveCommand extends BaseFvmCommand {
     if (argResults!.rest.isEmpty) {
       final versions = await get<CacheService>().getAllVersions();
       version = logger.cacheVersionSelector(versions);
+    } else {
+      version = argResults!.rest[0];
     }
-    // Assign if its empty
-    version ??= argResults!.rest[0];
     final validVersion = FlutterVersion.parse(version);
     final cacheVersion = get<CacheService>().getVersion(validVersion);
 

--- a/lib/src/commands/use_command.dart
+++ b/lib/src/commands/use_command.dart
@@ -74,10 +74,10 @@ class UseCommand extends BaseFvmCommand {
       final versions = await get<CacheService>().getAllVersions();
       // If no config found, ask which version to select.
       version ??= logger.cacheVersionSelector(versions);
+    } else {
+      // Get version from first arg
+      version = firstRestArg;
     }
-
-    // Get version from first arg
-    version ??= firstRestArg;
 
     // At this point, version could still be null, so we need to ensure it's not
     if (version == null) {

--- a/lib/src/services/flutter_service.dart
+++ b/lib/src/services/flutter_service.dart
@@ -349,7 +349,7 @@ class VersionRunner {
 
     logger.debug('Starting to update environment variables...');
 
-    final updatedEnvironment = Map<String, String>.from(env);
+    final updatedEnvironment = Map<String, String>.of(env);
 
     final envPath = env['PATH'] ?? '';
 

--- a/lib/src/utils/helpers.dart
+++ b/lib/src/utils/helpers.dart
@@ -281,7 +281,7 @@ Map<String, String> updateEnvironmentVariables(
   // Remove duplicates
   paths = paths.toSet().toList();
 
-  final updatedEnvironment = Map<String, String>.from(env);
+  final updatedEnvironment = Map<String, String>.of(env);
   final envPath = env['PATH'] ?? '';
   final separator = Platform.isWindows ? ';' : ':';
 


### PR DESCRIPTION
## Summary
- Fixed unused variable assignment warnings in command classes by replacing `??=` patterns with proper if-else logic
- Replaced `Map.from()` with `Map.of()` for better performance in environment variable handling functions

## Changes
- `remove_command.dart`: Fixed unused assignment at line 56
- `global_command.dart`: Fixed unused assignment at line 71  
- `use_command.dart`: Fixed unused assignments at lines 73 and 76
- `flutter_service.dart`: Changed `Map.from()` to `Map.of()` at line 352
- `helpers.dart`: Changed `Map.from()` to `Map.of()` at line 284

## Test plan
- [ ] Verify all lint warnings are resolved
- [ ] Test command functionality remains unchanged
- [ ] Ensure no regression in version selection logic