### PR TITLE
docs: update PATH for global version setup

### DIFF
--- a/docs/pages/documentation/guides/workflows.mdx
+++ b/docs/pages/documentation/guides/workflows.mdx
@@ -108,7 +108,7 @@ Configure a system-wide default Flutter version.
 fvm global 3.19.0
 
 # Add to PATH (one-time setup)
-export PATH="$PATH:$HOME/.fvm/bin"
+export PATH="$PATH:$HOME/fvm/default/bin"
 
 # Use global version
 flutter doctor


### PR DESCRIPTION
I ran into a problem setting up a global flutter version via fvm. The problem seemed to be that this path in the docs is incorrect.