### PR TITLE
fix: add git commit step for clean pub.dev validation state

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,15 @@ jobs:
           echo "✅ Generated version.dart content:"
           cat lib/src/version.dart
 
+      - name: Commit version updates for clean git state
+        run: |
+          echo "📝 Committing version updates to create clean git state"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add pubspec.yaml lib/src/version.dart
+          git commit -m "chore: update version to $RELEASE_VERSION for release" || echo "No changes to commit"
+          echo "✅ Git state cleaned for publishing"
+
       - name: Validate pub.dev package (dry run)
         run: |
           echo "🔍 Validating package for pub.dev..."


### PR DESCRIPTION
## Problem
The release workflow validation was failing with git warnings:
- "2 checked-in files are modified in git" 
- `pubspec.yaml` and `lib/src/version.dart` were dirty after dynamic updates
- `dart pub publish --dry-run` complained about uncommitted changes

## Solution
Added automated git commit step in the validate job:
- ✅ Updates `pubspec.yaml` version dynamically
- ✅ Generates `version.dart` with build_runner  
- ✅ **Commits both files** using github-actions[bot]
- ✅ Creates clean git state for `dart pub publish --dry-run`
- ✅ Deploy jobs remain unchanged (grinder handles dirty state fine)

## Key Benefits
- 🧹 **Clean validation**: No more git warnings during dry-run
- 📝 **Version history**: Proper version commits in git history 
- 🚀 **Reliable publishing**: Clean state for all pub.dev operations
- ⚡ **Fast failure**: Still validates before expensive deployments

## Testing
Ready to test with manual dispatch: `v4.0.0-beta.2-test-clean`

🤖 Generated with Claude Code