### PR TITLE
feat: add automatic CHANGELOG entry linking to GitHub release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,12 +60,27 @@ jobs:
           echo "✅ Generated version.dart content:"
           cat lib/src/version.dart
 
+      - name: Update CHANGELOG with release link
+        run: |
+          echo "📝 Adding $RELEASE_VERSION entry to CHANGELOG.md"
+          TODAY=$(date +%Y-%m-%d)
+          awk -v version="$RELEASE_VERSION" -v date="$TODAY" '
+            /^## \[Unreleased\]/ { 
+              print; print ""; 
+              print "## [" version "] - " date; print ""; 
+              print "See [Release Notes](https://github.com/leoafarias/fvm/releases/tag/v" version ")"; print ""; 
+              next 
+            } 1' CHANGELOG.md > temp_changelog && mv temp_changelog CHANGELOG.md
+          echo "✅ Added $RELEASE_VERSION to CHANGELOG.md"
+          echo "📋 CHANGELOG.md preview:"
+          head -12 CHANGELOG.md
+
       - name: Commit version updates for clean git state
         run: |
           echo "📝 Committing version updates to create clean git state"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add pubspec.yaml lib/src/version.dart
+          git add pubspec.yaml lib/src/version.dart CHANGELOG.md
           git commit -m "chore: update version to $RELEASE_VERSION for release" || echo "No changes to commit"
           echo "✅ Git state cleaned for publishing"
 


### PR DESCRIPTION
## Summary
✅ **Completes the release workflow automation** by eliminating the final pub.dev warning

## Problem Solved
- ⚠️ pub.dev validation: "CHANGELOG.md doesn't mention current version (X.Y.Z)"
- This was the last remaining warning preventing clean package publishing

## Solution  
**Automatic CHANGELOG management:**
- ✅ **Trigger**: Creating GitHub release automatically updates CHANGELOG.md
- ✅ **Entry format**: `## [X.Y.Z] - YYYY-MM-DD` + link to GitHub release notes  
- ✅ **Placement**: Inserted after `## [Unreleased]` section
- ✅ **Clean commit**: CHANGELOG.md included in automated git commit

## Technical Implementation
- **Portable awk command**: Works on both Linux (GitHub Actions) and macOS
- **Self-referential**: Links to the exact GitHub release that triggered the workflow
- **Zero manual work**: Complete automation from GitHub release → deployment

## Expected Results
**Before**: `Package has 1 warning`  
**After**: `Package has 0 warnings` ✅

## Test Plan
1. Merge to main  
2. Manual dispatch test: `v4.0.0-final-test`
3. Verify: Zero pub.dev warnings
4. GitHub release test: Create actual release and confirm automatic trigger

🤖 Generated with Claude Code