### PR TITLE
fix: reorder pub validation to ensure clean git state

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,19 +72,24 @@ jobs:
           echo "📋 CHANGELOG.md preview:"
           head -12 CHANGELOG.md
 
-      - name: Validate pub.dev package (dry run)
+      - name: Commit version updates locally
         run: |
-          echo "🔍 Validating package for pub.dev..."
-          dart pub publish --dry-run --force
-          echo "✅ Package validation successful!"
-
-      - name: Commit and push version updates
-        run: |
-          echo "📝 Committing and pushing version updates to main"
+          echo "📝 Committing version updates locally"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add pubspec.yaml lib/src/version.dart CHANGELOG.md
           git commit -m "chore: update version to $RELEASE_VERSION for release" || echo "No changes to commit"
+          echo "✅ Changes committed locally"
+
+      - name: Validate pub.dev package (dry run)
+        run: |
+          echo "🔍 Validating package for pub.dev..."
+          dart pub publish --dry-run
+          echo "✅ Package validation successful!"
+
+      - name: Push version updates to main
+        run: |
+          echo "📤 Pushing version updates to main branch"
           git push origin main
           echo "✅ Changes pushed to main branch"
 


### PR DESCRIPTION
## Summary
- Reorder release workflow steps: commit locally → validate → push
- Remove conflicting `--force` flag from `dart pub publish --dry-run`
- Maintain fail-fast behavior while ensuring clean git state for pub validation

## Problem
The release workflow was failing with error: **"Cannot use both --force and --dry-run"**

The `--force` and `--dry-run` flags are mutually exclusive in `dart pub publish`. Additionally, pub dry-run expects a clean git state, but we were running validation before committing changes.

## Solution  
1. **Commit changes locally first** - ensures clean git state
2. **Run pub dry-run validation** - validates package without conflicts
3. **Push to remote only if validation passes** - maintains fail-fast behavior

## Benefits
- ✅ Fast failure on pub.dev validation issues
- ✅ Clean git state for pub dry-run command  
- ✅ Only pushes changes if validation succeeds
- ✅ Fixes the mutual exclusion error between --force and --dry-run

## Test plan
- [x] Remove conflicting --force flag
- [x] Reorder workflow steps for proper git state
- [ ] Test with v4.0.0-beta.2 release workflow