### PR TITLE
fix: resolve find command syntax error in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add pubspec.yaml lib/src/version.dart CHANGELOG.md
-          find lib -name "*.mapper.dart" -exec git add {} ;
+          git add lib/src/**/*.mapper.dart || true
           git commit -m "chore: update version to $RELEASE_VERSION for release" || echo "No changes to commit"
           echo "✅ Changes committed locally"
 


### PR DESCRIPTION
Quick fix for find command syntax error that was preventing the commit step from working. Simplifies to use git add with glob pattern and fallback.