### PR TITLE
fix: remove unnecessary mapper file handling from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,11 +74,10 @@ jobs:
 
       - name: Commit version updates locally
         run: |
-          echo "📝 Committing version updates and generated files locally"
+          echo "📝 Committing version updates locally"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add pubspec.yaml lib/src/version.dart CHANGELOG.md
-          find lib -name "*.mapper.dart" -exec git add {} \;
           git commit -m "chore: update version to $RELEASE_VERSION for release" || echo "No changes to commit"
           echo "✅ Changes committed locally"
 


### PR DESCRIPTION
## Summary
- Removes the problematic `find lib -name "*.mapper.dart" -exec git add {} \;` line from the release workflow
- The .mapper.dart files are already committed and tracked in the repository
- These files should not change during build_runner execution (validated by ensure_build_test.dart)

## Problem
The release workflow was failing with "find: missing argument to `-exec'` error because:
1. The find command syntax wasn't properly escaped for YAML
2. More importantly, these mapper files don't need to be added during release as they're already committed

## Solution
Simply remove the line attempting to add .mapper.dart files. The workflow now only commits the actual files that change during release:
- pubspec.yaml (version update)
- lib/src/version.dart (generated version file)
- CHANGELOG.md (release entry)

## Testing
This fix ensures the `pub dry-run` validation passes with a clean git state.

Fixes the v4.0.0-beta.2 release workflow failures.