### PR TITLE
fix: update Docker action versions to prevent deprecation warnings

### DIFF
--- a/.github/workflows/deploy_docker.yml
+++ b/.github/workflows/deploy_docker.yml
@@ -15,10 +15,10 @@ jobs:
             uses: ./.github/actions/prepare
     
           - name: Set up QEMU
-            uses: docker/setup-qemu-action@v1
+            uses: docker/setup-qemu-action@v3
     
           - name: Set up Docker Buildx
-            uses: docker/setup-buildx-action@v1
+            uses: docker/setup-buildx-action@v3
     
           - name: Login to DockerHub
             uses: docker/login-action@v3


### PR DESCRIPTION
## Summary

- Updated `docker/setup-qemu-action` from v1 to v3 in `deploy_docker.yml`
- Updated `docker/setup-buildx-action` from v1 to v3 in `deploy_docker.yml`
- Aligns with versions already used in `release.yml`

These v1 actions run on deprecated Node.js versions and will eventually stop working. The v3 versions use modern Node.js and prevent deprecation warnings.

## Test plan

- [ ] Verify workflow syntax is valid
- [ ] Confirm v3 actions are compatible with existing Docker build process
- [ ] Test Docker deployment workflow manually if needed