### PR TITLE
fix: remove mapper files git add from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,6 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add pubspec.yaml lib/src/version.dart CHANGELOG.md
-          git add lib/src/**/*.mapper.dart || true
           git commit -m "chore: update version to $RELEASE_VERSION for release" || echo "No changes to commit"
           echo "✅ Changes committed locally"
 


### PR DESCRIPTION
## Summary

- Remove unnecessary `git add lib/src/**/*.mapper.dart` from release workflow
- Rely on existing `build_verify` test to ensure generated files are up-to-date
- Fixes 20+ consecutive release workflow failures

## Problem

The release workflow has been failing consistently with two types of errors:

1. **Analyzer errors** due to out-of-sync mapper files
2. **Homebrew deployment failures** due to git add syntax issues

The root cause was the CI attempting to commit mapper files during the release process using a bash glob pattern that doesn't work reliably in GitHub Actions environment.

## Solution

The project already has `build_verify` configured in `test/ensure_build_test.dart`, which is the standard Dart approach for this problem. This test:

- ✅ Runs as part of the test suite (before deployment)
- ✅ Fails fast if generated files are out of sync
- ✅ Forces developers to run `build_runner` and commit mapper files before pushing
- ✅ Eliminates need for CI commits

By removing the workaround git add line, we adopt the standard approach and let the test suite catch issues early.

## Test Plan

- [x] Verify `build_verify` test exists at `test/ensure_build_test.dart`
- [x] Confirm test runs in CI workflow
- [ ] Monitor next release workflow run for success