### PR TITLE
fix(docs): correct broken links in getting started page

### DIFF
--- a/docs/pages/documentation/getting-started/index.md
+++ b/docs/pages/documentation/getting-started/index.md
@@ -32,6 +32,6 @@ fvm flutter doctor
 
 ## Next Steps
 
-1. [Install FVM](./installation) on your system
-2. [Configure](./configuration) your first project
-3. Check the [FAQ](./faq) for common questions
+1. [Install FVM](/documentation/getting-started/installation) on your system
+2. [Configure](/documentation/getting-started/configuration) your first project
+3. Check the [FAQ](/documentation/getting-started/faq) for common questions


### PR DESCRIPTION
## Summary

Fixes broken documentation links in the Getting Started overview page that were causing 404 errors.

## Problem

The "Next Steps" section on `/documentation/getting-started` used relative links (`./installation`, `./configuration`, `./faq`) which were incorrectly resolving to `/documentation/*` instead of `/documentation/getting-started/*`, resulting in 404 errors when users clicked these links.

## Solution

Updated the three links in the "Next Steps" section to use explicit absolute paths:
- `./installation` → `/documentation/getting-started/installation`
- `./configuration` → `/documentation/getting-started/configuration`
- `./faq` → `/documentation/getting-started/faq`

## Validation

- ✅ Verified broken link via Playwright: `/documentation/installation` returns 404
- ✅ Confirmed correct path works: `/documentation/getting-started/installation` returns 200
- ✅ Docs build successfully with no warnings or errors
- ✅ No other relative link issues found in documentation

## Files Changed

- `docs/pages/documentation/getting-started/index.md` - Updated 3 links in Next Steps section

Fixes #944