### PR TITLE
Add RISC-V (riscv64) architecture support

### DIFF
--- a/docs/pages/documentation/getting-started/installation.mdx
+++ b/docs/pages/documentation/getting-started/installation.mdx
@@ -130,7 +130,7 @@ The install script (`install.sh`) supports several options:
 | Platform | Architecture | Support |
 |----------|-------------|---------|
 | macOS | x64, arm64 | ✅ |
-| Linux | x64, arm64 | ✅ |
+| Linux | x64, arm64, riscv64 | ✅ |
 | Windows | x64 | ✅ (via PowerShell/Chocolatey) |
 
 ### Requirements

--- a/docs/public/install.sh
+++ b/docs/public/install.sh
@@ -246,8 +246,11 @@ case "$ARCH" in
   arm64|aarch64)
     ARCH='arm64'
     ;;
+  riscv64|riscv64gc)
+    ARCH='riscv64'
+    ;;
   *)
-    error "Unsupported architecture: $ARCH. Only x64 and arm64 are supported."
+    error "Unsupported architecture: $ARCH. Only x64, arm64, and riscv64 are supported."
     ;;
 esac
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -246,8 +246,11 @@ case "$ARCH" in
   arm64|aarch64)
     ARCH='arm64'
     ;;
+  riscv64|riscv64gc)
+    ARCH='riscv64'
+    ;;
   *)
-    error "Unsupported architecture: $ARCH. Only x64 and arm64 are supported."
+    error "Unsupported architecture: $ARCH. Only x64, arm64, and riscv64 are supported."
     ;;
 esac
 


### PR DESCRIPTION
## Summary

Adds RISC-V (riscv64) architecture support to FVM install scripts. RISC-V binaries are already being built and published by the release pipeline (available since v4.0.0), so this PR only adds the architecture detection logic to enable installations on riscv64 systems.

## Changes

- ✅ Added riscv64 architecture detection to `scripts/install.sh`
- ✅ Added riscv64 architecture detection to `docs/public/install.sh` (kept in sync)
- ✅ Updated documentation to list riscv64 as supported architecture on Linux
- ✅ Improved error messages to list all supported architectures

## Verification

- Tested architecture detection logic for all patterns (x86_64, arm64, aarch64, riscv64, riscv64gc)
- Confirmed RISC-V binaries are downloadable from GitHub releases:
  - `fvm-4.0.0-linux-riscv64.tar.gz` ✅
  - `fvm-4.0.0-linux-riscv64-musl.tar.gz` ✅

## Notes

The Dart SDK officially supports RISC-V (RV64GC) on Linux, and cli_pkg (v2.10.0) automatically generates build tasks for all Dart-supported architectures. The release workflow's `pkg-github-linux` command already includes RISC-V tasks, so binaries have been available since v4.0.0 was released.

Fixes #935