### PR TITLE
Support SSH fork URLs

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -890,4 +890,4 @@ packages:
     source: hosted
     version: "2.1.0"
 sdks:
-  dart: ">=3.6.0 <4.0.0"
+  dart: ">=3.8.0 <4.0.0"

--- a/test/commands/fork_command_test.dart
+++ b/test/commands/fork_command_test.dart
@@ -49,6 +49,34 @@ void main() {
       expect(fork.url, testForkUrl);
     });
 
+    test('Add a fork with scp-style git URL', () async {
+      const alias = 'sshfork';
+      const scpUrl = 'git@github.com:flutter/flutter.git';
+
+      LocalAppConfig.read()
+        ..forks.removeWhere((f) => f.name == alias)
+        ..save();
+
+      final exitCode = await runner.runOrThrow([
+        'fvm',
+        'fork',
+        'add',
+        alias,
+        scpUrl,
+      ]);
+
+      expect(exitCode, ExitCode.success.code);
+
+      final config = LocalAppConfig.read();
+      final fork = config.forks.firstWhere(
+        (f) => f.name == alias,
+        orElse: () => const FlutterFork(name: '', url: ''),
+      );
+
+      expect(fork.name, alias);
+      expect(fork.url, scpUrl);
+    });
+
     test('Reject invalid fork URL', () async {
       final invalidUrl = 'invalid-url';
 

--- a/test/utils/helpers_test.dart
+++ b/test/utils/helpers_test.dart
@@ -45,6 +45,51 @@ void main() {
     expect('100.0.0', assignVersionWeight('dev'));
   });
 
+  group('isValidGitUrl', () {
+    test('accepts common git transports with .git suffix', () {
+      expect(isValidGitUrl('https://github.com/flutter/flutter.git'), isTrue);
+      expect(isValidGitUrl('git://example.com/repo.git'), isTrue);
+      expect(
+        isValidGitUrl('ssh://git@github.com/flutter/flutter.git'),
+        isTrue,
+      );
+      expect(
+        isValidGitUrl('file:///Users/test/projects/flutter.git'),
+        isTrue,
+      );
+    });
+
+    test('accepts scp-style git urls including ipv6 hosts', () {
+      expect(
+        isValidGitUrl('git@github.com:flutter/flutter.git'),
+        isTrue,
+      );
+      expect(
+        isValidGitUrl('git@[2001:db8::1]:owner/project.git'),
+        isTrue,
+      );
+    });
+
+    test('accepts ssh urls that use scp-like namespace syntax', () {
+      expect(
+        isValidGitUrl('ssh://git@gitlab.com:group/project.git'),
+        isTrue,
+      );
+      expect(
+        isValidGitUrl('ssh://git@gitlab.com:7999/group/project.git'),
+        isTrue,
+      );
+    });
+
+    test('rejects malformed git urls', () {
+      expect(isValidGitUrl('https://github.com/flutter/flutter'), isFalse);
+      expect(isValidGitUrl('git@github.com:flutter/flutter'), isFalse);
+      expect(isValidGitUrl('ssh://git@gitlab.com'), isFalse);
+      expect(isValidGitUrl('not a url'), isFalse);
+      expect(isValidGitUrl(''), isFalse);
+    });
+  });
+
   group('extractFlutterVersionOutput', () {
     test('should correctly parse the EXAMPLE:1', () {
       final content =


### PR DESCRIPTION
## Summary
- allow scp-style and ssh git URLs when adding forks or configuring flutterUrl
- simplify git URL validation helpers and keep \ enforcement consistent
- add CLI and unit tests for the newly accepted URL formats

## Testing
- dart test
- dart analyze
- dcm analyze .

Fixes #881