### PR TITLE
Fix documentation links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,7 +8,7 @@ assignees: ""
 
 **Before creating a bug report please make check the following**
 
-- [ ] You have read our [FAQ](https://fvm.app/docs/guides/faq)
+- [ ] You have read our [FAQ](https://fvm.app/documentation/getting-started/faq)
 - [ ] If you have used flutter. Please install correctly, run `pub cache repair`. Close the terminal and try again.
 - [ ] If you are on Windows. Make sure you are running the terminal as `administrator` or with `developer` permissions.
 - [ ] Run `fvm doctor` if possible and add the output to the issue.

--- a/FVM_v4.0_GITHUB_RELEASE.md
+++ b/FVM_v4.0_GITHUB_RELEASE.md
@@ -118,9 +118,9 @@ This release was made possible by contributions from the Flutter community. Spec
 
 ## 📚 Documentation
 
-- Full documentation: [fvm.app](https://fvm.app)
-- Fork management guide: [fvm.app/docs/guides/fork-management](https://fvm.app/docs/guides/fork-management)
-- API reference: [fvm.app/docs/api](https://fvm.app/docs/api)
+- Full documentation: [fvm.app/documentation](https://fvm.app/documentation)
+- Fork management guide: [fvm.app/documentation/advanced/custom-version](https://fvm.app/documentation/advanced/custom-version)
+- API reference: [fvm.app/documentation/advanced/json-api](https://fvm.app/documentation/advanced/json-api)
 
 ## 🐛 Bug Reports
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ FVM manages Flutter SDK versions per project. Switch between Flutter versions in
 - Flutter's major updates demand total app migration.
 - Inconsistencies occur in development environments within teams.
 
-For more information, read [FVM documentation](https://fvm.app).
+For more information, read the [Getting Started guide](https://fvm.app/documentation/getting-started).
 
 ## Release Process (For Maintainers)
 
@@ -69,7 +69,7 @@ Checkout Flutter Sidekick. [Read more about it here.](https://github.com/leoafar
 
 ## Troubleshooting
 
-Please view our [FAQ](https://www.fvm.app/documentation/getting-started/faq).
+Please view our [FAQ](https://fvm.app/documentation/getting-started/faq).
 
 ## License
 


### PR DESCRIPTION
## Summary

-  point README CTA to the new onboarding guide
- align FAQ links with the reorganized documentation paths
- refresh v4.0 release notes to the current documentation URLs

Fixes #825.