### PR TITLE
chore: align chocolatey branding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Packaging
+
+* choco: Rename Chocolatey listing to "Flutter Version Management (FVM)" for improved discoverability.
+
 ## 4.0.0
 
 * add: Manage Flutter SDKs from custom or forked repositories

--- a/fvm.nuspec
+++ b/fvm.nuspec
@@ -34,7 +34,7 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
 
     <!-- == SOFTWARE SPECIFIC SECTION == -->
     <!-- This section is about the software itself -->
-    <title>fvm (Install)</title>
+    <title>Flutter Version Management (FVM)</title>
     <authors>leochocolatey</authors>
     <!-- projectUrl is required for the community feed -->
     <projectUrl>https://github.com/leoafarias/fvm</projectUrl>
@@ -49,8 +49,8 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
     <!--<mailingListUrl></mailingListUrl>-->
     <!--<bugTrackerUrl></bugTrackerUrl>-->
     <tags>fvm flutter versions sdk</tags>
-    <summary>Flutter Version Management: A simple cli to manage Flutter SDK versions per project</summary>
-    <description>FVM helps with the need for a consistent app builds by allowing to reference Flutter SDK version used on a per-project basis. It also allows you to have multiple Flutter versions installed to quickly validate and test upcoming Flutter releases with your apps, without waiting for Flutter installation every time. </description>
+    <summary>Flutter Version Management: A simple CLI to manage Flutter SDK versions per project</summary>
+    <description>Flutter Version Management (FVM) helps teams maintain consistent app builds by referencing the desired Flutter SDK version on a per-project basis. It also lets you install multiple Flutter versions to validate upcoming releases quickly, without waiting on a fresh Flutter installation each time. </description>
     <releaseNotes>https://github.com/leoafarias/fvm/blob/master/CHANGELOG.md</releaseNotes>
     <!-- =============================== -->      
 


### PR DESCRIPTION
## Summary
- Rename the Chocolatey package title to "Flutter Version Management (FVM)" for improved discoverability
- Update the nuspec summary/description to match the refreshed branding
- Note the packaging change in the changelog

## Testing
- `dart run grinder pkg-chocolatey-deploy --dry-run` (fails at `choco pack` locally because Chocolatey isn't installed)

Closes #933.