### PR TITLE
Add 3-second timeout for update checks

### DIFF
--- a/lib/src/runner.dart
+++ b/lib/src/runner.dart
@@ -89,11 +89,11 @@ class FvmCommandRunner extends CompletionCommandRunner<int> {
       final isUpToDate = await _pubUpdater.isUpToDate(
         packageName: kPackageName,
         currentVersion: packageVersion,
-      );
+      ).timeout(const Duration(seconds: 3));
 
       if (isUpToDate) return null;
 
-      final latestVersion = await _pubUpdater.getLatestVersion(kPackageName);
+      final latestVersion = await _pubUpdater.getLatestVersion(kPackageName).timeout(const Duration(seconds: 3));
 
       return () {
         final updateAvailableLabel = lightYellow.wrap('Update available!');
@@ -106,6 +106,10 @@ class FvmCommandRunner extends CompletionCommandRunner<int> {
             '$updateAvailableLabel $currentVersionLabel \u2192 $latestVersionLabel',
           )
           ..info();
+      };
+    } on TimeoutException {
+      return () {
+        logger.debug("Update check timed out.");
       };
     } catch (_) {
       return () {


### PR DESCRIPTION
## Summary

Adds timeout protection to prevent update checks from hanging indefinitely. Update checks now complete within 3 seconds or fail gracefully with specific logging for timeout vs other failures.

## Changes

- Wrap both `isUpToDate()` and `getLatestVersion()` calls with 3-second timeouts
- Add specific `TimeoutException` handler with debug logging
- Preserve existing error handling for other failures

## Impact

Update check no longer blocks command execution indefinitely if network is slow or unreachable. Users on slow connections will see debug logs on timeout instead of hanging.