### PR TITLE
chore(release): prepare v4.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 4.0.2
+
+* fix: version detection for Flutter 3.38+ (version file removal)
+* fix: filter hidden directories from cache version listing
+* fix: route conflict in documentation site navigation
+* docs: improve Android Studio/IntelliJ IDE configuration guide
+
 ## 4.0.1
 
 * add: `fvm install` now runs setup by default

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '4.0.1';
+const packageVersion = '4.0.2';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: fvm
 description: A simple cli to manage Flutter SDK versions per project. Support
   channels, releases, and local cache for fast switching between versions.
-version: 4.0.1
+version: 4.0.2
 homepage: https://github.com/leoafarias/fvm
 
 environment:


### PR DESCRIPTION
## Summary

Prepares FVM for v4.0.2 release with bug fixes for Flutter 3.38+ compatibility.

### Changes since v4.0.1:

- **fix**: Version detection for Flutter 3.38+ (#972) - Flutter removed the `version` file, now uses `git describe --tags` as fallback
- **fix**: Filter hidden directories (`.dart_tool`, `.DS_Store`) from cache version listing (#972)
- **fix**: Route conflict in documentation site navigation (#980)
- **docs**: Improve Android Studio/IntelliJ IDE configuration guide (#979)

### Files changed:
- `CHANGELOG.md` — new 4.0.2 section
- `pubspec.yaml` — version bumped to 4.0.2
- `lib/src/version.dart` — packageVersion updated to 4.0.2

## Release steps after merge

1. Create and push tag: `git tag v4.0.2 && git push origin v4.0.2`
2. Release workflow will automatically deploy to pub.dev, Homebrew, Chocolatey, and Docker Hub