### PR TITLE
fix: preserve all project settings on fvm install

### DIFF
--- a/lib/src/services/project_service.dart
+++ b/lib/src/services/project_service.dart
@@ -72,10 +72,12 @@ class ProjectService extends ContextualService {
         ? {...?currentConfig.flavors, ...flavors}
         : currentConfig.flavors;
 
-    final config = currentConfig.copyWith(
-      flutter: flutterSdkVersion,
-      flavors: mergedFlavors?.isNotEmpty == true ? mergedFlavors : null,
-      updateVscodeSettings: updateVscodeSettings,
+    final config = currentConfig.copyWith.$merge(
+      ProjectConfig(
+        flutter: flutterSdkVersion,
+        flavors: mergedFlavors?.isNotEmpty == true ? mergedFlavors : null,
+        updateVscodeSettings: updateVscodeSettings,
+      ),
     );
 
     // Update flavors

--- a/test/src/services/project_service_test.dart
+++ b/test/src/services/project_service_test.dart
@@ -120,5 +120,38 @@ void main() {
       expect(project.hasConfig, isFalse);
       expect(project.path, isNotNull);
     });
+
+    test('update preserves updateVscodeSettings when not specified', () {
+      final tempDir = tempDirs.create();
+
+      // Create initial config with updateVscodeSettings: false
+      final config = ProjectConfig(
+        flutter: '3.10.0',
+        updateVscodeSettings: false,
+      );
+      createProjectConfig(config, tempDir);
+
+      // Create pubspec.yaml
+      final pubspecFile = File(p.join(tempDir.path, 'pubspec.yaml'));
+      pubspecFile.writeAsStringSync('name: test_project');
+
+      // Load the project
+      final project = Project.loadFromDirectory(tempDir);
+
+      // Update without specifying updateVscodeSettings (should preserve false)
+      projectService.update(
+        project,
+        flutterSdkVersion: '3.16.0',
+      );
+
+      // Read back the updated configuration
+      final updatedProject = projectService.findAncestor(directory: tempDir);
+      final updatedConfig = updatedProject.config;
+
+      expect(updatedConfig, isNotNull);
+      expect(updatedConfig!.flutter, equals('3.16.0'));
+      // This is the key assertion: updateVscodeSettings should be preserved
+      expect(updatedConfig.updateVscodeSettings, isFalse);
+    });
   });
 }


### PR DESCRIPTION
## Summary
- Fixes #971
- Uses `copyWith.$merge()` to preserve ALL existing settings in `.fvmrc` when running `fvm install`
- Protects: `updateVscodeSettings`, `updateGitIgnore`, `updateMelosSettings`, `runPubGetOnSdkChanges`, `privilegedAccess`, `cachePath`, `useGitCache`, `gitCachePath`, `flutterUrl`
- Matches the pattern already used in `app_config_service.dart:46`

## Why \`$merge\` instead of null-coalescing?
From [dart_mappable docs](https://pub.dev/documentation/dart_mappable/latest/topics/Copy-With-topic.html):
- `copyWith()` with explicit null → **overwrites** the field (the bug)
- `copyWith.$merge()` with null → **preserves** existing value ✓

## Test plan
- [x] Added unit test `'update preserves updateVscodeSettings when not specified'`
- [x] All existing tests pass