### PR TITLE
fix: remove leading newline from fvm dart/flutter output

### DIFF
--- a/lib/src/workflows/run_configured_flutter.workflow.dart
+++ b/lib/src/workflows/run_configured_flutter.workflow.dart
@@ -39,8 +39,6 @@ class RunConfiguredFlutterWorkflow extends Workflow {
 
     // Execute using the selected version if available.
     if (selectedVersion != null) {
-      logger.info();
-
       return get<FlutterService>().run(cmd, args, selectedVersion);
     }
 


### PR DESCRIPTION
## Summary
- Removes the `logger.info()` call in `RunConfiguredFlutterWorkflow` that was outputting an unwanted newline to stdout before running flutter/dart commands

Fixes #982

## Test plan
- Run `fvm dart run helloworld.dart` and verify output starts with actual content, not a newline
- Run `fvm dart run script.dart | head -c 1 | xxd` and verify first byte is not `0a` (newline)