### PR TITLE
docs: add package manager installation in Linux section

### DIFF
--- a/docs/pages/documentation/getting-started/installation.mdx
+++ b/docs/pages/documentation/getting-started/installation.mdx
@@ -71,7 +71,12 @@ choco uninstall fvm
   </Tabs.Tab>
 
   <Tabs.Tab>
-## Install Script (Recommended)
+
+## Package Manager Installation
+
+[![Packaging status](https://repology.org/badge/vertical-allrepos/fvm.svg)](https://repology.org/project/fvm/versions)
+
+## Install Script
 
 Install the latest version:
 


### PR DESCRIPTION
- Add a Repology badge to display the versions and up to date status of FVM in all known repositories.
- Avoid marking install script as recommended, since using the package manager to install software is generally preferred on Linux.