### PR TITLE
docs: update windows path documentation

### DIFF
--- a/docs/pages/documentation/getting-started/installation.mdx
+++ b/docs/pages/documentation/getting-started/installation.mdx
@@ -167,7 +167,7 @@ export PATH="$PATH:$HOME/.pub-cache/bin"
 Add to your PATH environment variable:
 
 ```
-%USERPROFILE%\AppData\Local\Pub\Cache\bin
+%USERPROFILE%\fvm\default\bin
 ```
 
   </Tabs.Tab>


### PR DESCRIPTION
## Summary

This PR aims to correct the windows PATH installation instruction in the docs.

I recently got a new windows 11 laptop and while installing fvm via `choco install fvm` the PATH to it is not `%USERPROFILE%\AppData\Local\Pub\Cache\bin` but instead `%USERPROFILE%\fvm\default\bin`. 

## Changes
 * Update installation.mdx with windows PATH
 
## Review Notes
All changes are text-only.







