### PR TITLE
chore(release): prepare v4.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
-## Unreleased
+## 4.0.5
 
-* fix: PathAccessException in Nix/Home Manager environments with read-only shell configs (#897, #799)
+* feat: migrate install script to v2 with user-local default install (#967)
+* fix: disable auto-install of shell completions for Nix/Home Manager environments (#991)
+* fix: support legacy `.fvm/fvm_config.json` file loading (#996)
+* fix: improve PATH guidance for CI installs (#999)
 
 ## 4.0.4
 

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '4.0.4';
+const packageVersion = '4.0.5';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: fvm
 description: A simple cli to manage Flutter SDK versions per project. Support
   channels, releases, and local cache for fast switching between versions.
-version: 4.0.4
+version: 4.0.5
 homepage: https://github.com/leoafarias/fvm
 
 environment:


### PR DESCRIPTION
## Summary

Release preparation for FVM v4.0.5

## Changes

* feat: migrate install script to v2 with user-local default install (#967)
* fix: disable auto-install of shell completions for Nix/Home Manager environments (#991)
* fix: support legacy `.fvm/fvm_config.json` file loading (#996)
* fix: improve PATH guidance for CI installs (#999)