### PR TITLE
ci: make integration tests wait for all unit tests to pass

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,7 +119,7 @@ jobs:
   integration-test:
     name: Integration Tests on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    needs: test  # Only wait for main Ubuntu test - optimization
+    needs: [test, test-os]  # Wait for all unit tests before integration
     timeout-minutes: 45
 
     strategy:


### PR DESCRIPTION
Integration tests now depend on both the ubuntu test job and the platform-specific (macOS/Windows) test job. This prevents wasted CI resources when platform tests are failing.