### PR TITLE
chore: bump pub_updater to ^0.5.0

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -549,10 +549,10 @@ packages:
     dependency: "direct main"
     description:
       name: pub_updater
-      sha256: "54e8dc865349059ebe7f163d6acce7c89eb958b8047e6d6e80ce93b13d7c9e60"
+      sha256: "739a0161d73a6974c0675b864fb0cf5147305f7b077b7f03a58fa7a9ab3e7e7d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.0"
+    version: "0.5.0"
   pubspec_parse:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   meta: ^1.10.0
   path: ^1.9.0
   pub_semver: ^2.1.4
-  pub_updater: ^0.4.0
+  pub_updater: ^0.5.0
   scope: ^5.1.0
   yaml: ^3.1.2
   yaml_edit: ^2.2.0


### PR DESCRIPTION
## Summary

- Bumps `pub_updater` from `^0.4.0` to `^0.5.0`
- pub_updater 0.5.0 contains **no API changes** — only tightened dependency constraints in its `pubspec.yaml`
- Resolves incompatibility with packages that depend on `pub_updater ^0.5.0` in Dart pub workspaces (single shared dependency resolution)

Closes #1021

## Verification

- `dart pub get` succeeds
- `dart analyze` reports no issues
- All pub_updater 0.5.0 transitive dependency constraints are already satisfied by fvm's current lockfile (`http 1.3.0`, `json_annotation 4.9.0`, `process 5.0.3`, `pub_semver 2.2.0`)