### PR TITLE
Fix macOS installer arch detection under Rosetta

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -5,11 +5,13 @@ on:
     paths:
       - 'docs/public/install.sh'
       - 'docs/public/uninstall.sh'
+      - 'scripts/test-install-arch.sh'
       - '.github/workflows/test-install.yml'
   pull_request:
     paths:
       - 'docs/public/install.sh'
       - 'docs/public/uninstall.sh'
+      - 'scripts/test-install-arch.sh'
       - '.github/workflows/test-install.yml'
   workflow_dispatch:
 
@@ -29,6 +31,10 @@ jobs:
         run: shellcheck docs/public/install.sh
       - name: Shellcheck uninstall.sh
         run: shellcheck docs/public/uninstall.sh
+      - name: Shellcheck test-install-arch.sh
+        run: shellcheck scripts/test-install-arch.sh
+      - name: Test install.sh architecture detection
+        run: ./scripts/test-install-arch.sh
 
   # Test install.sh (v2 - user-local only)
   test-install:

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -6,12 +6,14 @@ on:
       - 'docs/public/install.sh'
       - 'docs/public/uninstall.sh'
       - 'scripts/test-install-arch.sh'
+      - 'scripts/test-install.sh'
       - '.github/workflows/test-install.yml'
   pull_request:
     paths:
       - 'docs/public/install.sh'
       - 'docs/public/uninstall.sh'
       - 'scripts/test-install-arch.sh'
+      - 'scripts/test-install.sh'
       - '.github/workflows/test-install.yml'
   workflow_dispatch:
 
@@ -33,8 +35,12 @@ jobs:
         run: shellcheck docs/public/uninstall.sh
       - name: Shellcheck test-install-arch.sh
         run: shellcheck scripts/test-install-arch.sh
+      - name: Shellcheck test-install.sh
+        run: shellcheck scripts/test-install.sh
       - name: Test install.sh architecture detection
         run: ./scripts/test-install-arch.sh
+      - name: Test install.sh behavior (root warning, execution guard)
+        run: ./scripts/test-install.sh
 
   # Test install.sh (v2 - user-local only)
   test-install:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ on:
       - "docs/public/install.sh"
       - "docs/public/uninstall.sh"
       - "scripts/install.ps1"
+      - "scripts/test-install-arch.sh"
       - "scripts/test-install.sh"
       - ".github/workflows/test-install.yml"
 
@@ -35,6 +36,7 @@ on:
       - "docs/public/install.sh"
       - "docs/public/uninstall.sh"
       - "scripts/install.ps1"
+      - "scripts/test-install-arch.sh"
       - "scripts/test-install.sh"
       - ".github/workflows/test-install.yml"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 * change: Git cache is now recreated as a bare mirror; on upgrade FVM migrates legacy caches and rewrites installed SDK alternates to point at the new mirror layout (expect a one-time repack when upgrading).
+* fix: make the macOS install script select the arm64 binary correctly when launched from a Rosetta-translated shell on Apple Silicon.
 
 ## 4.0.5
 

--- a/docs/public/install.sh
+++ b/docs/public/install.sh
@@ -132,6 +132,39 @@ print_installer_version() {
 
 require() { command -v "$1" >/dev/null 2>&1 || { echo "error: $1 is required" >&2; exit 1; }; }
 
+map_uname_arch() {
+  local uname_arch="${1:-$(uname -m)}"
+
+  case "$uname_arch" in
+    x86_64|amd64) printf '%s\n' "x64" ;;
+    aarch64|arm64) printf '%s\n' "arm64" ;;
+    armv7l|armv7|armv6l|armv6|armhf) printf '%s\n' "arm" ;;
+    riscv64) printf '%s\n' "riscv64" ;;
+    *)
+      echo "error: unsupported architecture: $uname_arch" >&2
+      exit 1
+      ;;
+  esac
+}
+
+detect_arch() {
+  local uname_s="$1"
+  local uname_arch
+  local arm64_capability
+
+  uname_arch="$(uname -m)"
+
+  if [ "$uname_s" = "Darwin" ]; then
+    arm64_capability="$(sysctl -n hw.optional.arm64 2>/dev/null || true)"
+    case "$arm64_capability" in
+      1) printf '%s\n' "arm64" ; return ;;
+      0) printf '%s\n' "x64" ; return ;;
+    esac
+  fi
+
+  map_uname_arch "$uname_arch"
+}
+
 normalize_version() { printf '%s\n' "${1#v}"; }
 
 get_latest_version() {
@@ -377,22 +410,24 @@ require tar
 [ -n "${BASH_VERSION:-}" ] || { echo "error: bash is required to run this installer" >&2; exit 1; }
 
 # ---- detect OS ----
-case "$(uname -s)" in
+RAW_UNAME_S="$(uname -s)"
+readonly RAW_UNAME_S
+
+case "$RAW_UNAME_S" in
   Linux)  OS="linux" ;;
   Darwin) OS="macos" ;;
-  *) echo "error: unsupported OS: $(uname -s)" >&2; exit 1 ;;
+  *) echo "error: unsupported OS: $RAW_UNAME_S" >&2; exit 1 ;;
 esac
 readonly OS
 
 # ---- detect ARCH ----
-case "$(uname -m)" in
-  x86_64|amd64)                   ARCH="x64" ;;
-  aarch64|arm64)                  ARCH="arm64" ;;
-  armv7l|armv7|armv6l|armv6|armhf) ARCH="arm" ;;
-  riscv64)                        ARCH="riscv64" ;;
-  *) echo "error: unsupported architecture: $(uname -m)" >&2; exit 1 ;;
-esac
+ARCH="$(detect_arch "$RAW_UNAME_S")"
 readonly ARCH
+
+if [ "${FVM_INSTALL_TEST_MODE:-}" = "print-target" ]; then
+  printf 'OS=%s ARCH=%s\n' "$OS" "$ARCH"
+  exit 0
+fi
 
 # ---- detect libc (Linux only), musl suffix only for x64/arm64 ----
 LIBC_SUFFIX=""

--- a/docs/public/install.sh
+++ b/docs/public/install.sh
@@ -11,9 +11,6 @@
 #   - Install to ~/.fvm_flutter/bin with /usr/local/bin symlink
 #   - Auto-modify shell config
 # =============================================================================
-set -euo pipefail
-umask 022
-
 # ---- installer metadata ----
 readonly INSTALLER_NAME="install_fvm.sh"
 readonly INSTALLER_VERSION="2.0.0"
@@ -147,22 +144,38 @@ map_uname_arch() {
   esac
 }
 
-detect_arch() {
-  local uname_s="$1"
-  local uname_arch
-  local arm64_capability
-
-  uname_arch="$(uname -m)"
-
-  if [ "$uname_s" = "Darwin" ]; then
-    arm64_capability="$(sysctl -n hw.optional.arm64 2>/dev/null || true)"
-    case "$arm64_capability" in
-      1) printf '%s\n' "arm64" ; return ;;
-      0) printf '%s\n' "x64" ; return ;;
-    esac
+resolve_sysctl_cmd() {
+  if [ -x "/usr/sbin/sysctl" ]; then
+    printf '%s\n' "/usr/sbin/sysctl"
+    return 0
   fi
 
-  map_uname_arch "$uname_arch"
+  local _sysctl
+  if _sysctl="$(command -v sysctl 2>/dev/null)"; then
+    printf '%s\n' "$_sysctl"
+    return 0
+  fi
+
+  return 1
+}
+
+detect_arch() {
+  local uname_s="$1"
+  local arm64_capability
+  local sysctl_cmd
+
+  if [ "$uname_s" = "Darwin" ]; then
+    sysctl_cmd="$(resolve_sysctl_cmd || true)"
+    if [ -n "$sysctl_cmd" ]; then
+      arm64_capability="$("$sysctl_cmd" -n hw.optional.arm64 2>/dev/null || true)"
+      case "$arm64_capability" in
+        1) printf '%s\n' "arm64" ; return ;;
+        0) printf '%s\n' "x64" ; return ;;
+      esac
+    fi
+  fi
+
+  map_uname_arch "$(uname -m)"
 }
 
 normalize_version() { printf '%s\n' "${1#v}"; }
@@ -360,190 +373,194 @@ do_uninstall() {
   exit 0
 }
 
-# ---- arg parsing ----
-for arg in "$@"; do
-  case "$arg" in
-    -h|--help) usage; exit 0 ;;
-    -v|--version) print_installer_version; exit 0 ;;
-    -u|--uninstall) UNINSTALL_ONLY=1 ;;
-    -*)
-      echo "error: unknown option: $arg" >&2
-      echo ""
-      usage
-      exit 1
-      ;;
-    *)
-      if [ -n "$REQUESTED_VERSION" ]; then
-        echo "error: multiple versions specified" >&2
+main() {
+  set -euo pipefail
+  umask 022
+
+  # ---- arg parsing ----
+  for arg in "$@"; do
+    case "$arg" in
+      -h|--help) usage; exit 0 ;;
+      -v|--version) print_installer_version; exit 0 ;;
+      -u|--uninstall) UNINSTALL_ONLY=1 ;;
+      -*)
+        echo "error: unknown option: $arg" >&2
+        echo ""
+        usage
         exit 1
-      fi
-      REQUESTED_VERSION="$arg"
-      ;;
-  esac
-done
+        ;;
+      *)
+        if [ -n "$REQUESTED_VERSION" ]; then
+          echo "error: multiple versions specified" >&2
+          exit 1
+        fi
+        REQUESTED_VERSION="$arg"
+        ;;
+    esac
+  done
 
-if [ -n "$REQUESTED_VERSION" ]; then
-  if ! [[ "$REQUESTED_VERSION" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z._-]+)?$ ]]; then
-    echo "error: invalid version format: $REQUESTED_VERSION (expected X.Y.Z or vX.Y.Z)" >&2
-    exit 1
-  fi
-fi
-
-# ---- handle uninstall ----
-if [ "$UNINSTALL_ONLY" -eq 1 ]; then
-  do_uninstall
-fi
-
-# ---- root user handling ----
-if [ "${EUID:-$(id -u)}" -eq 0 ]; then
-  echo "⚠ Warning: Running as root" >&2
-  echo "  FVM will be installed to $BIN_DIR and likely won't be accessible to other users." >&2
-  echo "  It is recommended that each user install FVM individually in their own home directory." >&2
-  echo "" >&2
-fi
-
-validate_install_base "$INSTALL_BASE"
-
-# ---- prereqs ----
-require curl
-require tar
-[ -n "${BASH_VERSION:-}" ] || { echo "error: bash is required to run this installer" >&2; exit 1; }
-
-# ---- detect OS ----
-RAW_UNAME_S="$(uname -s)"
-readonly RAW_UNAME_S
-
-case "$RAW_UNAME_S" in
-  Linux)  OS="linux" ;;
-  Darwin) OS="macos" ;;
-  *) echo "error: unsupported OS: $RAW_UNAME_S" >&2; exit 1 ;;
-esac
-readonly OS
-
-# ---- detect ARCH ----
-ARCH="$(detect_arch "$RAW_UNAME_S")"
-readonly ARCH
-
-if [ "${FVM_INSTALL_TEST_MODE:-}" = "print-target" ]; then
-  printf 'OS=%s ARCH=%s\n' "$OS" "$ARCH"
-  exit 0
-fi
-
-# ---- detect libc (Linux only), musl suffix only for x64/arm64 ----
-LIBC_SUFFIX=""
-if [ "$OS" = "linux" ] && { [ "$ARCH" = "x64" ] || [ "$ARCH" = "arm64" ]; }; then
-  # Detect glibc positively via getconf; otherwise check for musl
-  if command -v getconf >/dev/null 2>&1 && getconf GNU_LIBC_VERSION >/dev/null 2>&1; then
-    : # glibc detected
-  elif command -v ldd >/dev/null 2>&1 && ldd --version 2>&1 | grep -qi musl; then
-    LIBC_SUFFIX="-musl"
-    echo "" >&2
-    echo "Note: Detected musl libc (Alpine Linux)." >&2
-    echo "      Flutter SDK requires glibc. You may need: apk add gcompat" >&2
-    echo "" >&2
-  elif ls /lib/ld-musl-*.so.1 >/dev/null 2>&1 || ls /usr/lib/ld-musl-*.so.1 >/dev/null 2>&1; then
-    LIBC_SUFFIX="-musl"
-    echo "" >&2
-    echo "Note: Detected musl libc (Alpine Linux)." >&2
-    echo "      Flutter SDK requires glibc. You may need: apk add gcompat" >&2
-    echo "" >&2
-  fi
-fi
-readonly LIBC_SUFFIX
-
-# ---- resolve version ----
-if [ -n "$REQUESTED_VERSION" ]; then
-  VERSION="$(normalize_version "$REQUESTED_VERSION")"
-else
-  echo "Fetching latest FVM version..." >&2
-  VERSION="$(get_latest_version)" || { echo "error: failed to determine latest version" >&2; exit 1; }
-fi
-
-echo "Installing FVM ${VERSION} for ${OS}-${ARCH}${LIBC_SUFFIX}..." >&2
-
-# ---- construct asset URL and validate existence, with musl->glibc fallback ----
-TARBALL="fvm-${VERSION}-${OS}-${ARCH}${LIBC_SUFFIX}.tar.gz"
-URL="https://github.com/${REPO}/releases/download/${VERSION}/${TARBALL}"
-
-if ! curl -fsSLI -o /dev/null "$URL"; then
-  if [ -n "$LIBC_SUFFIX" ]; then
-    ALT_URL="https://github.com/${REPO}/releases/download/${VERSION}/fvm-${VERSION}-${OS}-${ARCH}.tar.gz"
-    if curl -fsSLI -o /dev/null "$ALT_URL"; then
-      URL="$ALT_URL"
-      TARBALL="fvm-${VERSION}-${OS}-${ARCH}.tar.gz"
-      echo "Note: Using glibc variant (musl not available)" >&2
-    else
-      echo "error: no asset found for ${OS}/${ARCH} (tried musl and glibc variants)" >&2
+  if [ -n "$REQUESTED_VERSION" ]; then
+    if ! [[ "$REQUESTED_VERSION" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z._-]+)?$ ]]; then
+      echo "error: invalid version format: $REQUESTED_VERSION (expected X.Y.Z or vX.Y.Z)" >&2
       exit 1
     fi
+  fi
+
+  # ---- handle uninstall ----
+  if [ "$UNINSTALL_ONLY" -eq 1 ]; then
+    do_uninstall
+  fi
+
+  # ---- root user handling ----
+  if [ "${EUID:-$(id -u)}" -eq 0 ]; then
+    echo "⚠ Warning: Running as root" >&2
+    echo "  FVM will be installed to $BIN_DIR and likely won't be accessible to other users." >&2
+    echo "  It is recommended that each user install FVM individually in their own home directory." >&2
+    echo "" >&2
+  fi
+
+  validate_install_base "$INSTALL_BASE"
+
+  # ---- prereqs ----
+  require curl
+  require tar
+  [ -n "${BASH_VERSION:-}" ] || { echo "error: bash is required to run this installer" >&2; exit 1; }
+
+  # ---- detect OS ----
+  RAW_UNAME_S="$(uname -s)"
+  readonly RAW_UNAME_S
+
+  case "$RAW_UNAME_S" in
+    Linux)  OS="linux" ;;
+    Darwin) OS="macos" ;;
+    *) echo "error: unsupported OS: $RAW_UNAME_S" >&2; exit 1 ;;
+  esac
+  readonly OS
+
+  # ---- detect ARCH ----
+  ARCH="$(detect_arch "$RAW_UNAME_S")"
+  readonly ARCH
+
+  # ---- detect libc (Linux only), musl suffix only for x64/arm64 ----
+  LIBC_SUFFIX=""
+  if [ "$OS" = "linux" ] && { [ "$ARCH" = "x64" ] || [ "$ARCH" = "arm64" ]; }; then
+    # Detect glibc positively via getconf; otherwise check for musl
+    if command -v getconf >/dev/null 2>&1 && getconf GNU_LIBC_VERSION >/dev/null 2>&1; then
+      : # glibc detected
+    elif command -v ldd >/dev/null 2>&1 && ldd --version 2>&1 | grep -qi musl; then
+      LIBC_SUFFIX="-musl"
+      echo "" >&2
+      echo "Note: Detected musl libc (Alpine Linux)." >&2
+      echo "      Flutter SDK requires glibc. You may need: apk add gcompat" >&2
+      echo "" >&2
+    elif ls /lib/ld-musl-*.so.1 >/dev/null 2>&1 || ls /usr/lib/ld-musl-*.so.1 >/dev/null 2>&1; then
+      LIBC_SUFFIX="-musl"
+      echo "" >&2
+      echo "Note: Detected musl libc (Alpine Linux)." >&2
+      echo "      Flutter SDK requires glibc. You may need: apk add gcompat" >&2
+      echo "" >&2
+    fi
+  fi
+  readonly LIBC_SUFFIX
+
+  # ---- resolve version ----
+  if [ -n "$REQUESTED_VERSION" ]; then
+    VERSION="$(normalize_version "$REQUESTED_VERSION")"
   else
-    echo "error: asset not found: $URL" >&2
+    echo "Fetching latest FVM version..." >&2
+    VERSION="$(get_latest_version)" || { echo "error: failed to determine latest version" >&2; exit 1; }
+  fi
+
+  echo "Installing FVM ${VERSION} for ${OS}-${ARCH}${LIBC_SUFFIX}..." >&2
+
+  # ---- construct asset URL and validate existence, with musl->glibc fallback ----
+  TARBALL="fvm-${VERSION}-${OS}-${ARCH}${LIBC_SUFFIX}.tar.gz"
+  URL="https://github.com/${REPO}/releases/download/${VERSION}/${TARBALL}"
+
+  if ! curl -fsSLI -o /dev/null "$URL"; then
+    if [ -n "$LIBC_SUFFIX" ]; then
+      ALT_URL="https://github.com/${REPO}/releases/download/${VERSION}/fvm-${VERSION}-${OS}-${ARCH}.tar.gz"
+      if curl -fsSLI -o /dev/null "$ALT_URL"; then
+        URL="$ALT_URL"
+        TARBALL="fvm-${VERSION}-${OS}-${ARCH}.tar.gz"
+        echo "Note: Using glibc variant (musl not available)" >&2
+      else
+        echo "error: no asset found for ${OS}/${ARCH} (tried musl and glibc variants)" >&2
+        exit 1
+      fi
+    else
+      echo "error: asset not found: $URL" >&2
+      exit 1
+    fi
+  fi
+
+  # ---- prep dirs and cleanup trap ----
+  TMP_DIR=""  # Initialize for set -u (nounset)
+  cleanup() { if [ -n "$TMP_DIR" ]; then rm -rf "$TMP_DIR" 2>/dev/null || true; fi; }
+  trap cleanup EXIT
+
+  TMP_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t 'fvm_install')" || {
+    echo "error: failed to create temp directory" >&2
+    exit 1
+  }
+  mkdir -p "$BIN_DIR"
+
+  # ---- download ----
+  ARCHIVE="${TMP_DIR}/${TARBALL}"
+  echo "Downloading ${URL##*/}..." >&2
+  curl -fsSL "$URL" -o "$ARCHIVE"
+
+  # ---- validate archive ----
+  if ! tar -tzf "$ARCHIVE" >/dev/null 2>&1; then
+    echo "error: downloaded archive appears corrupted" >&2
     exit 1
   fi
-fi
 
-# ---- prep dirs and cleanup trap ----
-TMP_DIR=""  # Initialize for set -u (nounset)
-cleanup() { if [ -n "$TMP_DIR" ]; then rm -rf "$TMP_DIR" 2>/dev/null || true; fi; }
-trap cleanup EXIT
+  # ---- validate no path traversal ----
+  if tar -tzf "$ARCHIVE" | grep -qE '^/|^\.\.$|^\.\./|/\.\.$|/\.\./'; then
+    echo "error: archive contains unsafe paths (absolute or traversal)" >&2
+    exit 1
+  fi
 
-TMP_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t 'fvm_install')" || {
-  echo "error: failed to create temp directory" >&2
-  exit 1
+  # ---- extract ----
+  echo "Extracting..." >&2
+  tar -xzf "$ARCHIVE" -C "$TMP_DIR"
+
+  # ---- locate binary and copy contents per tarball structure ----
+  if [ -d "${TMP_DIR}/fvm" ] && [ -f "${TMP_DIR}/fvm/fvm" ]; then
+    cp -a "${TMP_DIR}/fvm/." "$BIN_DIR/"
+  elif [ -f "${TMP_DIR}/fvm" ]; then
+    cp -a "${TMP_DIR}/fvm" "${BIN_DIR}/fvm"
+  else
+    FOUND="$(find "$TMP_DIR" -type f -name 'fvm' 2>/dev/null | head -n1 || true)"
+    [ -n "$FOUND" ] || { echo "error: fvm binary not found in archive" >&2; exit 1; }
+    cp -a "$FOUND" "${BIN_DIR}/fvm"
+  fi
+  chmod +x "${BIN_DIR}/fvm"
+
+  # ---- migrate from v1/v2 ----
+  migrate_from_v1
+
+  # ---- verify and report ----
+  echo ""
+  echo "Installed to: ${BIN_DIR}/fvm"
+
+  if "${BIN_DIR}/fvm" --version >/dev/null 2>&1; then
+    echo "FVM version: ${VERSION}"
+    print_path_instructions
+  else
+    echo ""
+    echo "⚠ Binary installed but cannot execute (missing libraries)."
+    echo "  On Alpine Linux: apk add gcompat"
+    echo "  Then verify: ${BIN_DIR}/fvm --version"
+    echo ""
+    echo "  PATH: export PATH=\"$BIN_DIR:\$PATH\""
+    if is_ci; then
+      exit 1
+    fi
+  fi
 }
-mkdir -p "$BIN_DIR"
 
-# ---- download ----
-ARCHIVE="${TMP_DIR}/${TARBALL}"
-echo "Downloading ${URL##*/}..." >&2
-curl -fsSL "$URL" -o "$ARCHIVE"
-
-# ---- validate archive ----
-if ! tar -tzf "$ARCHIVE" >/dev/null 2>&1; then
-  echo "error: downloaded archive appears corrupted" >&2
-  exit 1
-fi
-
-# ---- validate no path traversal ----
-if tar -tzf "$ARCHIVE" | grep -qE '^/|^\.\.$|^\.\./|/\.\.$|/\.\./'; then
-  echo "error: archive contains unsafe paths (absolute or traversal)" >&2
-  exit 1
-fi
-
-# ---- extract ----
-echo "Extracting..." >&2
-tar -xzf "$ARCHIVE" -C "$TMP_DIR"
-
-# ---- locate binary and copy contents per tarball structure ----
-if [ -d "${TMP_DIR}/fvm" ] && [ -f "${TMP_DIR}/fvm/fvm" ]; then
-  cp -a "${TMP_DIR}/fvm/." "$BIN_DIR/"
-elif [ -f "${TMP_DIR}/fvm" ]; then
-  cp -a "${TMP_DIR}/fvm" "${BIN_DIR}/fvm"
-else
-  FOUND="$(find "$TMP_DIR" -type f -name 'fvm' 2>/dev/null | head -n1 || true)"
-  [ -n "$FOUND" ] || { echo "error: fvm binary not found in archive" >&2; exit 1; }
-  cp -a "$FOUND" "${BIN_DIR}/fvm"
-fi
-chmod +x "${BIN_DIR}/fvm"
-
-# ---- migrate from v1/v2 ----
-migrate_from_v1
-
-# ---- verify and report ----
-echo ""
-echo "Installed to: ${BIN_DIR}/fvm"
-
-if "${BIN_DIR}/fvm" --version >/dev/null 2>&1; then
-  echo "FVM version: ${VERSION}"
-  print_path_instructions
-else
-  echo ""
-  echo "⚠ Binary installed but cannot execute (missing libraries)."
-  echo "  On Alpine Linux: apk add gcompat"
-  echo "  Then verify: ${BIN_DIR}/fvm --version"
-  echo ""
-  echo "  PATH: export PATH=\"$BIN_DIR:\$PATH\""
-  if is_ci; then
-    exit 1
-  fi
+if ! (return 0 2>/dev/null); then
+  main "$@"
 fi

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -34,6 +34,17 @@ Usage:
 sudo ./scripts/test-install.sh
 ```
 
+### test-install-arch.sh
+Deterministic regression test for install target selection:
+- Verifies macOS Rosetta-aware arm64 detection
+- Verifies Linux architecture mapping and unsupported-arch failures
+- Avoids downloads by stubbing `uname`, `sysctl`, `curl`, and `tar`
+
+Usage:
+```bash
+./scripts/test-install-arch.sh
+```
+
 ### install.ps1
 PowerShell installation script for Windows.
 

--- a/scripts/test-install-arch.sh
+++ b/scripts/test-install-arch.sh
@@ -14,10 +14,8 @@ INSTALL_SCRIPT="${REPO_ROOT}/docs/public/install.sh"
 BASH_BIN="$(command -v bash)"
 BASH_DIR="$(dirname "${BASH_BIN}")"
 TMP_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t 'fvm_install_arch_test')"
-CORE_STUB_DIR="${TMP_DIR}/core-bin"
-PATH_SYSCTL_DIR="${TMP_DIR}/path-bin"
-ABSOLUTE_SYSCTL_DIR="${TMP_DIR}/usr/sbin"
-ABSOLUTE_SYSCTL_PATH="${ABSOLUTE_SYSCTL_DIR}/sysctl"
+STUB_DIR="${TMP_DIR}/bin"
+SYSCTL_STUB="${TMP_DIR}/sysctl"
 TEST_HOME="${TMP_DIR}/home"
 
 cleanup() {
@@ -25,155 +23,84 @@ cleanup() {
 }
 trap cleanup EXIT
 
-mkdir -p "${CORE_STUB_DIR}" "${PATH_SYSCTL_DIR}" "${ABSOLUTE_SYSCTL_DIR}" "${TEST_HOME}"
+mkdir -p "${STUB_DIR}" "${TEST_HOME}"
 
-cat > "${CORE_STUB_DIR}/uname" <<'EOF'
+# Stub uname to return controlled values
+cat > "${STUB_DIR}/uname" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
-
 case "${1:-}" in
   -s) printf '%s\n' "${FVM_TEST_UNAME_S:?}" ;;
   -m) printf '%s\n' "${FVM_TEST_UNAME_M:?}" ;;
-  *)
-    echo "unexpected uname args: $*" >&2
-    exit 64
-    ;;
+  *)  echo "unexpected uname args: $*" >&2; exit 64 ;;
 esac
 EOF
 
-cat > "${PATH_SYSCTL_DIR}/sysctl" <<'EOF'
+# Stub sysctl that returns a controlled value or fails
+cat > "${SYSCTL_STUB}" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
-
-case "${FVM_TEST_PATH_SYSCTL_MODE:-value}" in
-  fail)
-    exit 1
-    ;;
-  value)
-    if [ "${1:-}" = "-n" ] && [ "${2:-}" = "hw.optional.arm64" ]; then
-      printf '%s\n' "${FVM_TEST_PATH_SYSCTL_VALUE:?}"
-    else
-      echo "unexpected sysctl args: $*" >&2
-      exit 65
-    fi
-    ;;
-  *)
-    echo "unexpected sysctl mode: ${FVM_TEST_PATH_SYSCTL_MODE:-}" >&2
-    exit 66
-    ;;
-esac
+if [ "${FVM_TEST_SYSCTL_MODE:-value}" = "fail" ]; then
+  exit 1
+fi
+if [ "${1:-}" = "-n" ] && [ "${2:-}" = "hw.optional.arm64" ]; then
+  printf '%s\n' "${FVM_TEST_SYSCTL_VALUE:?}"
+else
+  echo "unexpected sysctl args: $*" >&2; exit 65
+fi
 EOF
 
-cat > "${ABSOLUTE_SYSCTL_PATH}" <<'EOF'
-#!/usr/bin/env bash
-set -euo pipefail
+chmod +x "${STUB_DIR}/uname" "${SYSCTL_STUB}"
 
-case "${FVM_TEST_ABSOLUTE_SYSCTL_MODE:-value}" in
-  fail)
-    exit 1
-    ;;
-  value)
-    if [ "${1:-}" = "-n" ] && [ "${2:-}" = "hw.optional.arm64" ]; then
-      printf '%s\n' "${FVM_TEST_ABSOLUTE_SYSCTL_VALUE:?}"
-    else
-      echo "unexpected sysctl args: $*" >&2
-      exit 65
-    fi
-    ;;
-  *)
-    echo "unexpected sysctl mode: ${FVM_TEST_ABSOLUTE_SYSCTL_MODE:-}" >&2
-    exit 66
-    ;;
-esac
-EOF
-
-chmod +x \
-  "${CORE_STUB_DIR}/uname" \
-  "${PATH_SYSCTL_DIR}/sysctl" \
-  "${ABSOLUTE_SYSCTL_PATH}"
-
-run_target_detection() {
+# Run detect_arch in an isolated subprocess with stubbed commands.
+# sysctl_mode: "value" (returns sysctl_value), "fail" (sysctl exits 1), "missing" (no sysctl)
+run_detect_arch() {
   local uname_s="$1"
   local uname_m="$2"
-  local path_sysctl_mode="$3"
-  local path_sysctl_value="$4"
-  local absolute_sysctl_mode="$5"
-  local absolute_sysctl_value="$6"
-  local path_prefix="${CORE_STUB_DIR}"
-
-  if [ "$path_sysctl_mode" != "missing" ]; then
-    path_prefix="${PATH_SYSCTL_DIR}:${CORE_STUB_DIR}"
-  fi
+  local sysctl_mode="$3"
+  local sysctl_value="${4:-}"
 
   # shellcheck disable=SC2016
   env \
-    PATH="${path_prefix}:${BASH_DIR}" \
+    PATH="${STUB_DIR}:${BASH_DIR}" \
     HOME="${TEST_HOME}" \
     FVM_TEST_UNAME_S="${uname_s}" \
     FVM_TEST_UNAME_M="${uname_m}" \
-    FVM_TEST_PATH_SYSCTL_MODE="${path_sysctl_mode}" \
-    FVM_TEST_PATH_SYSCTL_VALUE="${path_sysctl_value}" \
-    FVM_TEST_ABSOLUTE_SYSCTL_MODE="${absolute_sysctl_mode}" \
-    FVM_TEST_ABSOLUTE_SYSCTL_VALUE="${absolute_sysctl_value}" \
+    FVM_TEST_SYSCTL_MODE="${sysctl_mode}" \
+    FVM_TEST_SYSCTL_VALUE="${sysctl_value}" \
     INSTALL_SCRIPT="${INSTALL_SCRIPT}" \
-    ABSOLUTE_SYSCTL_PATH="${ABSOLUTE_SYSCTL_PATH}" \
+    SYSCTL_STUB="${SYSCTL_STUB}" \
     "${BASH_BIN}" -c '
       set -euo pipefail
-
       source "$INSTALL_SCRIPT"
 
+      # Override resolve_sysctl_cmd to use our stub (or simulate missing)
       resolve_sysctl_cmd() {
-        if [ "${FVM_TEST_ABSOLUTE_SYSCTL_MODE}" != "missing" ]; then
-          printf "%s\n" "$ABSOLUTE_SYSCTL_PATH"
-          return 0
+        if [ "${FVM_TEST_SYSCTL_MODE}" = "missing" ]; then
+          return 1
         fi
-
-        if [ "${FVM_TEST_PATH_SYSCTL_MODE}" != "missing" ]; then
-          command -v sysctl
-          return 0
-        fi
-
-        return 1
+        printf "%s\n" "$SYSCTL_STUB"
+        return 0
       }
 
-      case "${FVM_TEST_UNAME_S}" in
-        Linux) os="linux" ;;
-        Darwin) os="macos" ;;
-        *)
-          echo "error: unsupported OS: ${FVM_TEST_UNAME_S}" >&2
-          exit 1
-          ;;
-      esac
-
       arch="$(detect_arch "${FVM_TEST_UNAME_S}")"
-      printf "OS=%s ARCH=%s\n" "$os" "$arch"
+      printf "%s\n" "$arch"
     '
 }
 
-assert_target() {
+assert_arch() {
   local description="$1"
   local expected="$2"
   local uname_s="$3"
   local uname_m="$4"
-  local path_sysctl_mode="$5"
-  local path_sysctl_value="$6"
-  local absolute_sysctl_mode="$7"
-  local absolute_sysctl_value="$8"
+  local sysctl_mode="$5"
+  local sysctl_value="${6:-}"
   local output
 
-  output="$(
-    run_target_detection \
-      "${uname_s}" \
-      "${uname_m}" \
-      "${path_sysctl_mode}" \
-      "${path_sysctl_value}" \
-      "${absolute_sysctl_mode}" \
-      "${absolute_sysctl_value}"
-  )"
+  output="$(run_detect_arch "${uname_s}" "${uname_m}" "${sysctl_mode}" "${sysctl_value}")"
   if [ "${output}" != "${expected}" ]; then
     fail "${description} -> expected '${expected}', got '${output}'"
   fi
-
   pass "${description}"
 }
 
@@ -183,171 +110,39 @@ assert_failure() {
   local output
 
   set +e
-  output="$(
-    # shellcheck disable=SC2016
-    env \
-      PATH="${CORE_STUB_DIR}:${BASH_DIR}" \
-      HOME="${TEST_HOME}" \
-      FVM_TEST_UNAME_S="Linux" \
-      FVM_TEST_UNAME_M="mips64" \
-      FVM_TEST_PATH_SYSCTL_MODE="missing" \
-      FVM_TEST_PATH_SYSCTL_VALUE="" \
-      FVM_TEST_ABSOLUTE_SYSCTL_MODE="missing" \
-      FVM_TEST_ABSOLUTE_SYSCTL_VALUE="" \
-      INSTALL_SCRIPT="${INSTALL_SCRIPT}" \
-      ABSOLUTE_SYSCTL_PATH="${ABSOLUTE_SYSCTL_PATH}" \
-      "${BASH_BIN}" -c '
-        set -euo pipefail
-
-        source "$INSTALL_SCRIPT"
-
-        resolve_sysctl_cmd() {
-          return 1
-        }
-
-        detect_arch "Linux"
-      ' 2>&1
-  )"
+  output="$(run_detect_arch "Linux" "mips64" "missing" "" 2>&1)"
   local status=$?
   set -e
 
   if [ "${status}" -eq 0 ]; then
     fail "${description} -> expected non-zero exit"
   fi
-
   if ! printf '%s' "${output}" | grep -Fq "${expected_fragment}"; then
-    fail "${description} -> expected output to contain '${expected_fragment}', got '${output}'"
+    fail "${description} -> expected '${expected_fragment}', got '${output}'"
   fi
-
   pass "${description}"
 }
 
 echo "🧪 Testing install.sh architecture detection"
 echo "============================================"
 
-assert_target \
-  "Darwin under Rosetta still selects arm64" \
-  "OS=macos ARCH=arm64" \
-  "Darwin" \
-  "x86_64" \
-  "value" \
-  "1" \
-  "missing" \
-  ""
+# Darwin + sysctl (the Rosetta fix)
+assert_arch "Darwin under Rosetta selects arm64"       "arm64"   "Darwin" "x86_64" "value" "1"
+assert_arch "Intel macOS selects x64"                   "x64"     "Darwin" "x86_64" "value" "0"
 
-assert_target \
-  "Intel macOS selects x64" \
-  "OS=macos ARCH=x64" \
-  "Darwin" \
-  "x86_64" \
-  "value" \
-  "0" \
-  "missing" \
-  ""
+# Darwin fallbacks when sysctl is unavailable
+assert_arch "Darwin falls back to uname arm64 when sysctl fails"   "arm64" "Darwin" "arm64"  "fail"
+assert_arch "Darwin falls back to uname x64 when sysctl fails"     "x64"   "Darwin" "x86_64" "fail"
+assert_arch "Darwin falls back to uname arm64 when sysctl missing" "arm64" "Darwin" "arm64"  "missing"
+assert_arch "Darwin falls back to uname x64 when sysctl missing"   "x64"   "Darwin" "x86_64" "missing"
 
-assert_target \
-  "Darwin arm64 falls back to uname when sysctl fails" \
-  "OS=macos ARCH=arm64" \
-  "Darwin" \
-  "arm64" \
-  "fail" \
-  "" \
-  "missing" \
-  ""
+# Linux arch mapping
+assert_arch "Linux aarch64 maps to arm64"   "arm64"   "Linux" "aarch64" "missing"
+assert_arch "Linux armv7l maps to arm"      "arm"     "Linux" "armv7l"  "missing"
+assert_arch "Linux riscv64 maps to riscv64" "riscv64" "Linux" "riscv64" "missing"
 
-assert_target \
-  "Darwin x64 falls back to uname when sysctl fails" \
-  "OS=macos ARCH=x64" \
-  "Darwin" \
-  "x86_64" \
-  "fail" \
-  "" \
-  "missing" \
-  ""
-
-assert_target \
-  "Darwin uses absolute-path sysctl for arm64 when PATH sysctl is absent" \
-  "OS=macos ARCH=arm64" \
-  "Darwin" \
-  "x86_64" \
-  "missing" \
-  "" \
-  "value" \
-  "1"
-
-assert_target \
-  "Darwin uses absolute-path sysctl for x64 when PATH sysctl is absent" \
-  "OS=macos ARCH=x64" \
-  "Darwin" \
-  "x86_64" \
-  "missing" \
-  "" \
-  "value" \
-  "0"
-
-assert_target \
-  "Darwin falls back to uname when absolute-path sysctl fails" \
-  "OS=macos ARCH=arm64" \
-  "Darwin" \
-  "arm64" \
-  "missing" \
-  "" \
-  "fail" \
-  ""
-
-assert_target \
-  "Darwin falls back to uname arm64 when no sysctl is available" \
-  "OS=macos ARCH=arm64" \
-  "Darwin" \
-  "arm64" \
-  "missing" \
-  "" \
-  "missing" \
-  ""
-
-assert_target \
-  "Darwin falls back to uname x64 when no sysctl is available" \
-  "OS=macos ARCH=x64" \
-  "Darwin" \
-  "x86_64" \
-  "missing" \
-  "" \
-  "missing" \
-  ""
-
-assert_target \
-  "Linux aarch64 maps to arm64" \
-  "OS=linux ARCH=arm64" \
-  "Linux" \
-  "aarch64" \
-  "missing" \
-  "" \
-  "missing" \
-  ""
-
-assert_target \
-  "Linux armv7l maps to arm" \
-  "OS=linux ARCH=arm" \
-  "Linux" \
-  "armv7l" \
-  "missing" \
-  "" \
-  "missing" \
-  ""
-
-assert_target \
-  "Linux riscv64 maps to riscv64" \
-  "OS=linux ARCH=riscv64" \
-  "Linux" \
-  "riscv64" \
-  "missing" \
-  "" \
-  "missing" \
-  ""
-
-assert_failure \
-  "Unsupported architectures still fail" \
-  "error: unsupported architecture: mips64"
+# Error case
+assert_failure "Unsupported architecture fails" "error: unsupported architecture: mips64"
 
 echo ""
 echo "✅ All architecture tests passed!"

--- a/scripts/test-install-arch.sh
+++ b/scripts/test-install-arch.sh
@@ -11,8 +11,13 @@ fail() { echo -e "${RED}❌ $1${NC}"; exit 1; }
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 INSTALL_SCRIPT="${REPO_ROOT}/docs/public/install.sh"
+BASH_BIN="$(command -v bash)"
+BASH_DIR="$(dirname "${BASH_BIN}")"
 TMP_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t 'fvm_install_arch_test')"
-STUB_DIR="${TMP_DIR}/bin"
+CORE_STUB_DIR="${TMP_DIR}/core-bin"
+PATH_SYSCTL_DIR="${TMP_DIR}/path-bin"
+ABSOLUTE_SYSCTL_DIR="${TMP_DIR}/usr/sbin"
+ABSOLUTE_SYSCTL_PATH="${ABSOLUTE_SYSCTL_DIR}/sysctl"
 TEST_HOME="${TMP_DIR}/home"
 
 cleanup() {
@@ -20,9 +25,9 @@ cleanup() {
 }
 trap cleanup EXIT
 
-mkdir -p "${STUB_DIR}" "${TEST_HOME}"
+mkdir -p "${CORE_STUB_DIR}" "${PATH_SYSCTL_DIR}" "${ABSOLUTE_SYSCTL_DIR}" "${TEST_HOME}"
 
-cat > "${STUB_DIR}/uname" <<'EOF'
+cat > "${CORE_STUB_DIR}/uname" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 
@@ -36,58 +41,113 @@ case "${1:-}" in
 esac
 EOF
 
-cat > "${STUB_DIR}/sysctl" <<'EOF'
+cat > "${PATH_SYSCTL_DIR}/sysctl" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 
-case "${FVM_TEST_SYSCTL_MODE:-value}" in
+case "${FVM_TEST_PATH_SYSCTL_MODE:-value}" in
   fail)
     exit 1
     ;;
   value)
     if [ "${1:-}" = "-n" ] && [ "${2:-}" = "hw.optional.arm64" ]; then
-      printf '%s\n' "${FVM_TEST_SYSCTL_VALUE:?}"
+      printf '%s\n' "${FVM_TEST_PATH_SYSCTL_VALUE:?}"
     else
       echo "unexpected sysctl args: $*" >&2
       exit 65
     fi
     ;;
   *)
-    echo "unexpected sysctl mode: ${FVM_TEST_SYSCTL_MODE:-}" >&2
+    echo "unexpected sysctl mode: ${FVM_TEST_PATH_SYSCTL_MODE:-}" >&2
     exit 66
     ;;
 esac
 EOF
 
-cat > "${STUB_DIR}/curl" <<'EOF'
+cat > "${ABSOLUTE_SYSCTL_PATH}" <<'EOF'
 #!/usr/bin/env bash
-echo "unexpected curl invocation: $*" >&2
-exit 97
+set -euo pipefail
+
+case "${FVM_TEST_ABSOLUTE_SYSCTL_MODE:-value}" in
+  fail)
+    exit 1
+    ;;
+  value)
+    if [ "${1:-}" = "-n" ] && [ "${2:-}" = "hw.optional.arm64" ]; then
+      printf '%s\n' "${FVM_TEST_ABSOLUTE_SYSCTL_VALUE:?}"
+    else
+      echo "unexpected sysctl args: $*" >&2
+      exit 65
+    fi
+    ;;
+  *)
+    echo "unexpected sysctl mode: ${FVM_TEST_ABSOLUTE_SYSCTL_MODE:-}" >&2
+    exit 66
+    ;;
+esac
 EOF
 
-cat > "${STUB_DIR}/tar" <<'EOF'
-#!/usr/bin/env bash
-echo "unexpected tar invocation: $*" >&2
-exit 98
-EOF
+chmod +x \
+  "${CORE_STUB_DIR}/uname" \
+  "${PATH_SYSCTL_DIR}/sysctl" \
+  "${ABSOLUTE_SYSCTL_PATH}"
 
-chmod +x "${STUB_DIR}/uname" "${STUB_DIR}/sysctl" "${STUB_DIR}/curl" "${STUB_DIR}/tar"
-
-run_install() {
+run_target_detection() {
   local uname_s="$1"
   local uname_m="$2"
-  local sysctl_mode="$3"
-  local sysctl_value="${4:-}"
+  local path_sysctl_mode="$3"
+  local path_sysctl_value="$4"
+  local absolute_sysctl_mode="$5"
+  local absolute_sysctl_value="$6"
+  local path_prefix="${CORE_STUB_DIR}"
 
+  if [ "$path_sysctl_mode" != "missing" ]; then
+    path_prefix="${PATH_SYSCTL_DIR}:${CORE_STUB_DIR}"
+  fi
+
+  # shellcheck disable=SC2016
   env \
-    PATH="${STUB_DIR}:$PATH" \
+    PATH="${path_prefix}:${BASH_DIR}" \
     HOME="${TEST_HOME}" \
-    FVM_INSTALL_TEST_MODE="print-target" \
     FVM_TEST_UNAME_S="${uname_s}" \
     FVM_TEST_UNAME_M="${uname_m}" \
-    FVM_TEST_SYSCTL_MODE="${sysctl_mode}" \
-    FVM_TEST_SYSCTL_VALUE="${sysctl_value}" \
-    bash "${INSTALL_SCRIPT}"
+    FVM_TEST_PATH_SYSCTL_MODE="${path_sysctl_mode}" \
+    FVM_TEST_PATH_SYSCTL_VALUE="${path_sysctl_value}" \
+    FVM_TEST_ABSOLUTE_SYSCTL_MODE="${absolute_sysctl_mode}" \
+    FVM_TEST_ABSOLUTE_SYSCTL_VALUE="${absolute_sysctl_value}" \
+    INSTALL_SCRIPT="${INSTALL_SCRIPT}" \
+    ABSOLUTE_SYSCTL_PATH="${ABSOLUTE_SYSCTL_PATH}" \
+    "${BASH_BIN}" -c '
+      set -euo pipefail
+
+      source "$INSTALL_SCRIPT"
+
+      resolve_sysctl_cmd() {
+        if [ "${FVM_TEST_ABSOLUTE_SYSCTL_MODE}" != "missing" ]; then
+          printf "%s\n" "$ABSOLUTE_SYSCTL_PATH"
+          return 0
+        fi
+
+        if [ "${FVM_TEST_PATH_SYSCTL_MODE}" != "missing" ]; then
+          command -v sysctl
+          return 0
+        fi
+
+        return 1
+      }
+
+      case "${FVM_TEST_UNAME_S}" in
+        Linux) os="linux" ;;
+        Darwin) os="macos" ;;
+        *)
+          echo "error: unsupported OS: ${FVM_TEST_UNAME_S}" >&2
+          exit 1
+          ;;
+      esac
+
+      arch="$(detect_arch "${FVM_TEST_UNAME_S}")"
+      printf "OS=%s ARCH=%s\n" "$os" "$arch"
+    '
 }
 
 assert_target() {
@@ -95,11 +155,21 @@ assert_target() {
   local expected="$2"
   local uname_s="$3"
   local uname_m="$4"
-  local sysctl_mode="$5"
-  local sysctl_value="${6:-}"
+  local path_sysctl_mode="$5"
+  local path_sysctl_value="$6"
+  local absolute_sysctl_mode="$7"
+  local absolute_sysctl_value="$8"
   local output
 
-  output="$(run_install "${uname_s}" "${uname_m}" "${sysctl_mode}" "${sysctl_value}")"
+  output="$(
+    run_target_detection \
+      "${uname_s}" \
+      "${uname_m}" \
+      "${path_sysctl_mode}" \
+      "${path_sysctl_value}" \
+      "${absolute_sysctl_mode}" \
+      "${absolute_sysctl_value}"
+  )"
   if [ "${output}" != "${expected}" ]; then
     fail "${description} -> expected '${expected}', got '${output}'"
   fi
@@ -114,14 +184,29 @@ assert_failure() {
 
   set +e
   output="$(
+    # shellcheck disable=SC2016
     env \
-      PATH="${STUB_DIR}:$PATH" \
+      PATH="${CORE_STUB_DIR}:${BASH_DIR}" \
       HOME="${TEST_HOME}" \
-      FVM_INSTALL_TEST_MODE="print-target" \
       FVM_TEST_UNAME_S="Linux" \
       FVM_TEST_UNAME_M="mips64" \
-      FVM_TEST_SYSCTL_MODE="fail" \
-      bash "${INSTALL_SCRIPT}" 2>&1
+      FVM_TEST_PATH_SYSCTL_MODE="missing" \
+      FVM_TEST_PATH_SYSCTL_VALUE="" \
+      FVM_TEST_ABSOLUTE_SYSCTL_MODE="missing" \
+      FVM_TEST_ABSOLUTE_SYSCTL_VALUE="" \
+      INSTALL_SCRIPT="${INSTALL_SCRIPT}" \
+      ABSOLUTE_SYSCTL_PATH="${ABSOLUTE_SYSCTL_PATH}" \
+      "${BASH_BIN}" -c '
+        set -euo pipefail
+
+        source "$INSTALL_SCRIPT"
+
+        resolve_sysctl_cmd() {
+          return 1
+        }
+
+        detect_arch "Linux"
+      ' 2>&1
   )"
   local status=$?
   set -e
@@ -146,7 +231,9 @@ assert_target \
   "Darwin" \
   "x86_64" \
   "value" \
-  "1"
+  "1" \
+  "missing" \
+  ""
 
 assert_target \
   "Intel macOS selects x64" \
@@ -154,42 +241,109 @@ assert_target \
   "Darwin" \
   "x86_64" \
   "value" \
-  "0"
+  "0" \
+  "missing" \
+  ""
 
 assert_target \
   "Darwin arm64 falls back to uname when sysctl fails" \
   "OS=macos ARCH=arm64" \
   "Darwin" \
   "arm64" \
-  "fail"
+  "fail" \
+  "" \
+  "missing" \
+  ""
 
 assert_target \
   "Darwin x64 falls back to uname when sysctl fails" \
   "OS=macos ARCH=x64" \
   "Darwin" \
   "x86_64" \
-  "fail"
+  "fail" \
+  "" \
+  "missing" \
+  ""
+
+assert_target \
+  "Darwin uses absolute-path sysctl for arm64 when PATH sysctl is absent" \
+  "OS=macos ARCH=arm64" \
+  "Darwin" \
+  "x86_64" \
+  "missing" \
+  "" \
+  "value" \
+  "1"
+
+assert_target \
+  "Darwin uses absolute-path sysctl for x64 when PATH sysctl is absent" \
+  "OS=macos ARCH=x64" \
+  "Darwin" \
+  "x86_64" \
+  "missing" \
+  "" \
+  "value" \
+  "0"
+
+assert_target \
+  "Darwin falls back to uname when absolute-path sysctl fails" \
+  "OS=macos ARCH=arm64" \
+  "Darwin" \
+  "arm64" \
+  "missing" \
+  "" \
+  "fail" \
+  ""
+
+assert_target \
+  "Darwin falls back to uname arm64 when no sysctl is available" \
+  "OS=macos ARCH=arm64" \
+  "Darwin" \
+  "arm64" \
+  "missing" \
+  "" \
+  "missing" \
+  ""
+
+assert_target \
+  "Darwin falls back to uname x64 when no sysctl is available" \
+  "OS=macos ARCH=x64" \
+  "Darwin" \
+  "x86_64" \
+  "missing" \
+  "" \
+  "missing" \
+  ""
 
 assert_target \
   "Linux aarch64 maps to arm64" \
   "OS=linux ARCH=arm64" \
   "Linux" \
   "aarch64" \
-  "fail"
+  "missing" \
+  "" \
+  "missing" \
+  ""
 
 assert_target \
   "Linux armv7l maps to arm" \
   "OS=linux ARCH=arm" \
   "Linux" \
   "armv7l" \
-  "fail"
+  "missing" \
+  "" \
+  "missing" \
+  ""
 
 assert_target \
   "Linux riscv64 maps to riscv64" \
   "OS=linux ARCH=riscv64" \
   "Linux" \
   "riscv64" \
-  "fail"
+  "missing" \
+  "" \
+  "missing" \
+  ""
 
 assert_failure \
   "Unsupported architectures still fail" \

--- a/scripts/test-install-arch.sh
+++ b/scripts/test-install-arch.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RED=$'\033[0;31m'
+GREEN=$'\033[0;32m'
+NC=$'\033[0m'
+
+pass() { echo -e "${GREEN}✅ $1${NC}"; }
+fail() { echo -e "${RED}❌ $1${NC}"; exit 1; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+INSTALL_SCRIPT="${REPO_ROOT}/docs/public/install.sh"
+TMP_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t 'fvm_install_arch_test')"
+STUB_DIR="${TMP_DIR}/bin"
+TEST_HOME="${TMP_DIR}/home"
+
+cleanup() {
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+mkdir -p "${STUB_DIR}" "${TEST_HOME}"
+
+cat > "${STUB_DIR}/uname" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+  -s) printf '%s\n' "${FVM_TEST_UNAME_S:?}" ;;
+  -m) printf '%s\n' "${FVM_TEST_UNAME_M:?}" ;;
+  *)
+    echo "unexpected uname args: $*" >&2
+    exit 64
+    ;;
+esac
+EOF
+
+cat > "${STUB_DIR}/sysctl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${FVM_TEST_SYSCTL_MODE:-value}" in
+  fail)
+    exit 1
+    ;;
+  value)
+    if [ "${1:-}" = "-n" ] && [ "${2:-}" = "hw.optional.arm64" ]; then
+      printf '%s\n' "${FVM_TEST_SYSCTL_VALUE:?}"
+    else
+      echo "unexpected sysctl args: $*" >&2
+      exit 65
+    fi
+    ;;
+  *)
+    echo "unexpected sysctl mode: ${FVM_TEST_SYSCTL_MODE:-}" >&2
+    exit 66
+    ;;
+esac
+EOF
+
+cat > "${STUB_DIR}/curl" <<'EOF'
+#!/usr/bin/env bash
+echo "unexpected curl invocation: $*" >&2
+exit 97
+EOF
+
+cat > "${STUB_DIR}/tar" <<'EOF'
+#!/usr/bin/env bash
+echo "unexpected tar invocation: $*" >&2
+exit 98
+EOF
+
+chmod +x "${STUB_DIR}/uname" "${STUB_DIR}/sysctl" "${STUB_DIR}/curl" "${STUB_DIR}/tar"
+
+run_install() {
+  local uname_s="$1"
+  local uname_m="$2"
+  local sysctl_mode="$3"
+  local sysctl_value="${4:-}"
+
+  env \
+    PATH="${STUB_DIR}:$PATH" \
+    HOME="${TEST_HOME}" \
+    FVM_INSTALL_TEST_MODE="print-target" \
+    FVM_TEST_UNAME_S="${uname_s}" \
+    FVM_TEST_UNAME_M="${uname_m}" \
+    FVM_TEST_SYSCTL_MODE="${sysctl_mode}" \
+    FVM_TEST_SYSCTL_VALUE="${sysctl_value}" \
+    bash "${INSTALL_SCRIPT}"
+}
+
+assert_target() {
+  local description="$1"
+  local expected="$2"
+  local uname_s="$3"
+  local uname_m="$4"
+  local sysctl_mode="$5"
+  local sysctl_value="${6:-}"
+  local output
+
+  output="$(run_install "${uname_s}" "${uname_m}" "${sysctl_mode}" "${sysctl_value}")"
+  if [ "${output}" != "${expected}" ]; then
+    fail "${description} -> expected '${expected}', got '${output}'"
+  fi
+
+  pass "${description}"
+}
+
+assert_failure() {
+  local description="$1"
+  local expected_fragment="$2"
+  local output
+
+  set +e
+  output="$(
+    env \
+      PATH="${STUB_DIR}:$PATH" \
+      HOME="${TEST_HOME}" \
+      FVM_INSTALL_TEST_MODE="print-target" \
+      FVM_TEST_UNAME_S="Linux" \
+      FVM_TEST_UNAME_M="mips64" \
+      FVM_TEST_SYSCTL_MODE="fail" \
+      bash "${INSTALL_SCRIPT}" 2>&1
+  )"
+  local status=$?
+  set -e
+
+  if [ "${status}" -eq 0 ]; then
+    fail "${description} -> expected non-zero exit"
+  fi
+
+  if ! printf '%s' "${output}" | grep -Fq "${expected_fragment}"; then
+    fail "${description} -> expected output to contain '${expected_fragment}', got '${output}'"
+  fi
+
+  pass "${description}"
+}
+
+echo "🧪 Testing install.sh architecture detection"
+echo "============================================"
+
+assert_target \
+  "Darwin under Rosetta still selects arm64" \
+  "OS=macos ARCH=arm64" \
+  "Darwin" \
+  "x86_64" \
+  "value" \
+  "1"
+
+assert_target \
+  "Intel macOS selects x64" \
+  "OS=macos ARCH=x64" \
+  "Darwin" \
+  "x86_64" \
+  "value" \
+  "0"
+
+assert_target \
+  "Darwin arm64 falls back to uname when sysctl fails" \
+  "OS=macos ARCH=arm64" \
+  "Darwin" \
+  "arm64" \
+  "fail"
+
+assert_target \
+  "Darwin x64 falls back to uname when sysctl fails" \
+  "OS=macos ARCH=x64" \
+  "Darwin" \
+  "x86_64" \
+  "fail"
+
+assert_target \
+  "Linux aarch64 maps to arm64" \
+  "OS=linux ARCH=arm64" \
+  "Linux" \
+  "aarch64" \
+  "fail"
+
+assert_target \
+  "Linux armv7l maps to arm" \
+  "OS=linux ARCH=arm" \
+  "Linux" \
+  "armv7l" \
+  "fail"
+
+assert_target \
+  "Linux riscv64 maps to riscv64" \
+  "OS=linux ARCH=riscv64" \
+  "Linux" \
+  "riscv64" \
+  "fail"
+
+assert_failure \
+  "Unsupported architectures still fail" \
+  "error: unsupported architecture: mips64"
+
+echo ""
+echo "✅ All architecture tests passed!"

--- a/scripts/test-install-arch.sh
+++ b/scripts/test-install-arch.sh
@@ -52,6 +52,43 @@ EOF
 
 chmod +x "${STUB_DIR}/uname" "${SYSCTL_STUB}"
 
+# Verify the shipped helper still prefers /usr/sbin/sysctl over PATH sysctl.
+# This catches regressions back to PATH-only resolution on macOS hosts.
+assert_resolve_sysctl_prefers_absolute_path() {
+  local output
+
+  if [ ! -x "/usr/sbin/sysctl" ]; then
+    echo "ℹ️  Skipping absolute-path sysctl precedence check on this host"
+    return 0
+  fi
+
+  cat > "${STUB_DIR}/sysctl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "fake-path-sysctl"
+EOF
+  chmod +x "${STUB_DIR}/sysctl"
+
+  # shellcheck disable=SC2016
+  output="$(
+    env \
+      PATH="${STUB_DIR}:${BASH_DIR}" \
+      HOME="${TEST_HOME}" \
+      INSTALL_SCRIPT="${INSTALL_SCRIPT}" \
+      "${BASH_BIN}" -c '
+        set -euo pipefail
+        source "$INSTALL_SCRIPT"
+        resolve_sysctl_cmd
+      '
+  )"
+
+  if [ "${output}" != "/usr/sbin/sysctl" ]; then
+    fail "resolve_sysctl_cmd prefers absolute path -> expected '/usr/sbin/sysctl', got '${output}'"
+  fi
+
+  pass "resolve_sysctl_cmd prefers absolute path over PATH"
+}
+
 # Run detect_arch in an isolated subprocess with stubbed commands.
 # sysctl_mode: "value" (returns sysctl_value), "fail" (sysctl exits 1), "missing" (no sysctl)
 run_detect_arch() {
@@ -125,6 +162,8 @@ assert_failure() {
 
 echo "🧪 Testing install.sh architecture detection"
 echo "============================================"
+
+assert_resolve_sysctl_prefers_absolute_path
 
 # Darwin + sysctl (the Rosetta fix)
 assert_arch "Darwin under Rosetta selects arm64"       "arm64"   "Darwin" "x86_64" "value" "1"

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -75,4 +75,22 @@ else
 fi
 
 echo ""
+echo "🧪 Testing execution guard (direct, piped, sourced)"
+echo "=================================================="
+echo ""
+
+# Direct execution: main runs, --help prints usage
+direct_output="$(bash ./docs/public/install.sh --help 2>&1)"
+assert_contains "$direct_output" "FVM Installer"
+
+# Piped execution (curl | bash path): main runs, --help prints usage
+piped_output="$(cat ./docs/public/install.sh | bash -s -- --help 2>&1)"
+assert_contains "$piped_output" "FVM Installer"
+
+# Sourced: main does NOT run, functions are available
+sourced_output="$(bash -c 'source ./docs/public/install.sh; type -t detect_arch' 2>&1)"
+assert_contains "$sourced_output" "function"
+assert_not_contains "$sourced_output" "Fetching latest"
+
+echo ""
 echo "✅ All tests passed!"

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -84,7 +84,7 @@ direct_output="$(bash ./docs/public/install.sh --help 2>&1)"
 assert_contains "$direct_output" "FVM Installer"
 
 # Piped execution (curl | bash path): main runs, --help prints usage
-piped_output="$(cat ./docs/public/install.sh | bash -s -- --help 2>&1)"
+piped_output="$(bash -s -- --help < ./docs/public/install.sh 2>&1)"
 assert_contains "$piped_output" "FVM Installer"
 
 # Sourced: main does NOT run, functions are available


### PR DESCRIPTION
Fix `install.sh` architecture detection on macOS by preferring `sysctl hw.optional.arm64`, with a `/usr/sbin/sysctl` fallback when `PATH` does not expose it.

Refactor the installer into a sourceable `main()` entrypoint and add `scripts/test-install-arch.sh` so Rosetta, fallback, and Linux architecture mapping cases can be tested without downloads.

Wire the new regression script into the install workflow, keep it excluded from the broader CLI workflow, and document the fix in the changelog and scripts README.