### PR TITLE
chore: consolidate test temp folders

### DIFF
--- a/fvm_mcp/test/process_runner_test.dart
+++ b/fvm_mcp/test/process_runner_test.dart
@@ -11,6 +11,11 @@ void main() {
 
   Future<String> _compileFakeFvm() async {
     final tmp = await Directory.systemTemp.createTemp('fvm_mcp_fake_fvm_');
+    addTearDown(() async {
+      if (await tmp.exists()) {
+        await tmp.delete(recursive: true);
+      }
+    });
     final outName = Platform.isWindows ? 'fake_fvm.exe' : 'fake_fvm';
     final outPath = '${tmp.path}/$outName';
 

--- a/test/commands/enhanced_install_test.dart
+++ b/test/commands/enhanced_install_test.dart
@@ -85,9 +85,7 @@ void main() {
     group('Install from project configuration:', () {
       test('Install without version uses project config', () async {
         // Create a temporary directory for this test
-        final tempDir = Directory.systemTemp.createTempSync(
-          'fvm_install_test_',
-        );
+        final tempDir = createTempDir('fvm_install_test');
         final originalDir = Directory.current;
 
         try {

--- a/test/integration/migration_from_v3_test.dart
+++ b/test/integration/migration_from_v3_test.dart
@@ -4,6 +4,8 @@ import 'dart:io';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
+import '../testing_utils.dart';
+
 Future<ProcessResult> _run(
   List<String> cmd, {
   required Map<String, String> env,
@@ -44,7 +46,7 @@ void main() {
   late String fvmLegacyExe;
 
   setUpAll(() {
-    tempHome = Directory.systemTemp.createTempSync('fvm_migration_it');
+    tempHome = createTempDir('fvm_migration_it');
     env = {
       ...Platform.environment,
       // FVM v3 reads FVM_HOME; newer versions use FVM_CACHE_PATH. Keep both
@@ -57,9 +59,8 @@ void main() {
       'PUB_CACHE': p.join(tempHome.path, '.pub-cache'),
     };
     final binDir = p.join(env['PUB_CACHE']!, 'bin');
-    fvmLegacyExe = Platform.isWindows
-        ? p.join(binDir, 'fvm.bat')
-        : p.join(binDir, 'fvm');
+    fvmLegacyExe =
+        Platform.isWindows ? p.join(binDir, 'fvm.bat') : p.join(binDir, 'fvm');
     env['PATH'] =
         '$binDir${Platform.isWindows ? ';' : ':'}${Platform.environment['PATH'] ?? ''}';
 
@@ -67,10 +68,14 @@ void main() {
     // Flutter (some golden file names exceed the legacy 260-char limit).
     if (Platform.isWindows) {
       final result = Process.runSync(
-        'git',
-        ['config', '--global', 'core.longpaths', 'true'],
-        environment: env,
-      );
+          'git',
+          [
+            'config',
+            '--global',
+            'core.longpaths',
+            'true',
+          ],
+          environment: env);
       if (result.exitCode != 0) {
         throw Exception('Failed to enable git longpaths: ${result.stderr}');
       }
@@ -95,69 +100,73 @@ void main() {
   test(
     'migrates cache from fvm 3.x to current',
     () async {
-    // 1) Install legacy fvm 3.x
-    await _run(
-      ['dart', 'pub', 'global', 'activate', 'fvm', '3.2.1'],
-      env: env,
-    );
+      // 1) Install legacy fvm 3.x
+      await _run([
+        'dart',
+        'pub',
+        'global',
+        'activate',
+        'fvm',
+        '3.2.1',
+      ], env: env);
 
-    // helper to run the legacy fvm binary
-    Future<void> legacyInstall(String target) async {
-      // Use the fully-qualified legacy fvm path to avoid PATH resolution
-      // issues on Windows runners where .bat lookup can be flaky.
-      await _run([fvmLegacyExe, 'install', target], env: env);
-    }
+      // helper to run the legacy fvm binary
+      Future<void> legacyInstall(String target) async {
+        // Use the fully-qualified legacy fvm path to avoid PATH resolution
+        // issues on Windows runners where .bat lookup can be flaky.
+        await _run([fvmLegacyExe, 'install', target], env: env);
+      }
 
-    // 2) Install a channel and a numbered release with legacy fvm
-    await legacyInstall('stable');
-    await legacyInstall('beta');
-    await legacyInstall('3.10.0');
+      // 2) Install a channel and a numbered release with legacy fvm
+      await legacyInstall('stable');
+      await legacyInstall('beta');
+      await legacyInstall('3.10.0');
 
-    // Legacy cache should be non-bare
-    final legacyBare = await Process.run(
-      'git',
-      ['rev-parse', '--is-bare-repository'],
-      environment: env,
-      workingDirectory: p.join(tempHome.path, 'cache.git'),
-    );
-    expect((legacyBare.stdout as String?)?.trim().toLowerCase(), equals('false'));
+      // Legacy cache should be non-bare
+      final legacyBare = await Process.run(
+        'git',
+        ['rev-parse', '--is-bare-repository'],
+        environment: env,
+        workingDirectory: p.join(tempHome.path, 'cache.git'),
+      );
+      expect(
+        (legacyBare.stdout as String?)?.trim().toLowerCase(),
+        equals('false'),
+      );
 
-    // 3) Run current fvm (repo code) to trigger migration
-    await _run(
-      ['dart', 'run', 'bin/main.dart', 'install', 'stable'],
-      env: env,
-      cwd: Directory.current.path,
-    );
+      // 3) Run current fvm (repo code) to trigger migration
+      await _run(
+        ['dart', 'run', 'bin/main.dart', 'install', 'stable'],
+        env: env,
+        cwd: Directory.current.path,
+      );
 
-    // 4) Assert cache is now bare
-    final cacheGitPath = p.join(tempHome.path, 'cache.git');
-    final newBare = await _run(
-      ['git', 'rev-parse', '--is-bare-repository'],
-      env: env,
-      cwd: cacheGitPath,
-    );
-    final isBare = (newBare.stdout as String?)?.trim().toLowerCase();
-    // Migration should produce a bare mirror
-    expect(isBare, 'true');
+      // 4) Assert cache is now bare
+      final cacheGitPath = p.join(tempHome.path, 'cache.git');
+      final newBare = await _run(
+        ['git', 'rev-parse', '--is-bare-repository'],
+        env: env,
+        cwd: cacheGitPath,
+      );
+      final isBare = (newBare.stdout as String?)?.trim().toLowerCase();
+      // Migration should produce a bare mirror
+      expect(isBare, 'true');
 
-    // 5) git status clean in each version
-    // Note: Legacy FVM 3.x doesn't use git cache with --reference, so versions
-    // installed by it won't have alternates files. We only verify the cache is
-    // bare and the versions remain functional.
-    for (final v in ['stable', 'beta', '3.10.0']) {
-      final status = await _run(
-        [
+      // 5) git status clean in each version
+      // Note: Legacy FVM 3.x doesn't use git cache with --reference, so versions
+      // installed by it won't have alternates files. We only verify the cache is
+      // bare and the versions remain functional.
+      for (final v in ['stable', 'beta', '3.10.0']) {
+        final status = await _run([
           'git',
           '-C',
           p.join(tempHome.path, 'versions', v),
           'status',
           '--short',
-        ],
-        env: env,
-      );
-      expect((status.stdout as String?)?.trim(), isEmpty);
-    }
-  },
+        ], env: env);
+        expect((status.stdout as String?)?.trim(), isEmpty);
+      }
+    },
     // Windows CI is significantly slower for git operations and Flutter cloning
     timeout: Timeout(Duration(minutes: 45)),
   );

--- a/test/services/cache_service_test.dart
+++ b/test/services/cache_service_test.dart
@@ -86,11 +86,13 @@ void main() {
           final versionDir = Directory(path.join(tempDir.path, version))
             ..createSync(recursive: true);
 
-          File(path.join(versionDir.path, 'version'))
-              .writeAsStringSync('$version (test)');
+          File(
+            path.join(versionDir.path, 'version'),
+          ).writeAsStringSync('$version (test)');
 
-          File(path.join(versionDir.path, 'bin', 'flutter'))
-              .createSync(recursive: true);
+          File(
+            path.join(versionDir.path, 'bin', 'flutter'),
+          ).createSync(recursive: true);
         }
 
         File(
@@ -119,7 +121,9 @@ void main() {
           final versionDir = Directory(path.join(tempDir.path, versionName))
             ..createSync(recursive: true);
 
-          Directory(path.join(versionDir.path, '.git')).createSync(recursive: true);
+          Directory(
+            path.join(versionDir.path, '.git'),
+          ).createSync(recursive: true);
           File(
             path.join(
               versionDir.path,
@@ -172,7 +176,6 @@ void main() {
           equals(CacheIntegrity.invalid),
         );
       });
-
     });
 
     group('moveToSdkVersionDirectory', () {
@@ -191,7 +194,6 @@ void main() {
           throwsA(isA<AppException>()),
         );
       });
-
     });
 
     group('Global version management:', () {
@@ -273,9 +275,7 @@ void main() {
       });
 
       test('getGlobalVersion falls back to basename for outside targets', () {
-        final outsideDir = Directory.systemTemp.createTempSync(
-          'fvm_outside_',
-        );
+        final outsideDir = createTempDir('fvm_outside');
         addTearDown(() => outsideDir.deleteSync(recursive: true));
         addTearDown(cacheService.unlinkGlobal);
 

--- a/test/services/flutter_service_test.dart
+++ b/test/services/flutter_service_test.dart
@@ -57,11 +57,7 @@ Future<void> _deleteLooseGitObject({
   }
 
   if (Platform.isWindows) {
-    await Process.run(
-      'attrib',
-      ['-R', objectFile.path],
-      runInShell: true,
-    );
+    await Process.run('attrib', ['-R', objectFile.path], runInShell: true);
   }
 
   final attempts = Platform.isWindows ? 3 : 1;
@@ -134,9 +130,7 @@ void main() {
       });
 
       test('preserves reference lookup errors from install flow', () async {
-        final tempDir = Directory.systemTemp.createTempSync(
-          'fvm_flutter_service_reference_error_',
-        );
+        final tempDir = createTempDir('fvm_flutter_service_reference_error');
 
         try {
           final remoteDir = await createLocalRemoteRepository(
@@ -179,66 +173,65 @@ void main() {
       });
 
       test(
-          'preserves reference lookup errors after retrying from mirror to remote',
-          () async {
-        final tempDir = Directory.systemTemp.createTempSync(
-          'fvm_flutter_service_reference_error_mirror_',
-        );
-
-        try {
-          final remoteDir = await createLocalRemoteRepository(
-            root: tempDir,
-            name: 'flutter_origin',
+        'preserves reference lookup errors after retrying from mirror to remote',
+        () async {
+          final tempDir = createTempDir(
+            'fvm_flutter_service_reference_error_mirror',
           );
 
-          final gitCachePath = p.join(tempDir.path, 'mirror.git');
-          Directory(gitCachePath).parent.createSync(recursive: true);
-          await runGitCommand([
-            'clone',
-            '--mirror',
-            remoteDir.path,
-            gitCachePath,
-          ]);
+          try {
+            final remoteDir = await createLocalRemoteRepository(
+              root: tempDir,
+              name: 'flutter_origin',
+            );
 
-          final context = FvmContext.create(
-            isTest: true,
-            configOverrides: AppConfig(
-              cachePath: p.join(tempDir.path, '.fvm'),
-              gitCachePath: gitCachePath,
-              flutterUrl: remoteDir.path,
-              useGitCache: true,
-            ),
-          );
+            final gitCachePath = p.join(tempDir.path, 'mirror.git');
+            Directory(gitCachePath).parent.createSync(recursive: true);
+            await runGitCommand([
+              'clone',
+              '--mirror',
+              remoteDir.path,
+              gitCachePath,
+            ]);
 
-          final service = FlutterService(context);
-          final version = FlutterVersion.parse('does-not-exist-1234');
+            final context = FvmContext.create(
+              isTest: true,
+              configOverrides: AppConfig(
+                cachePath: p.join(tempDir.path, '.fvm'),
+                gitCachePath: gitCachePath,
+                flutterUrl: remoteDir.path,
+                useGitCache: true,
+              ),
+            );
 
-          await expectLater(
-            service.install(version),
-            throwsA(
-              isA<AppException>().having(
-                (e) => e.message,
-                'message',
-                allOf(
-                  contains(
-                    'Reference "${version.version}" was not found in the Flutter repository.',
+            final service = FlutterService(context);
+            final version = FlutterVersion.parse('does-not-exist-1234');
+
+            await expectLater(
+              service.install(version),
+              throwsA(
+                isA<AppException>().having(
+                  (e) => e.message,
+                  'message',
+                  allOf(
+                    contains(
+                      'Reference "${version.version}" was not found in the Flutter repository.',
+                    ),
+                    contains('Repository URL: ${remoteDir.path}'),
                   ),
-                  contains('Repository URL: ${remoteDir.path}'),
                 ),
               ),
-            ),
-          );
-        } finally {
-          if (tempDir.existsSync()) {
-            tempDir.deleteSync(recursive: true);
+            );
+          } finally {
+            if (tempDir.existsSync()) {
+              tempDir.deleteSync(recursive: true);
+            }
           }
-        }
-      });
+        },
+      );
 
       test('clones from local mirror and rewrites origin URL', () async {
-        final tempDir = Directory.systemTemp.createTempSync(
-          'fvm_flutter_service_mirror_',
-        );
+        final tempDir = createTempDir('fvm_flutter_service_mirror');
 
         try {
           final remoteDir = await createLocalRemoteRepository(
@@ -274,21 +267,16 @@ void main() {
           final cacheService = context.get<CacheService>();
           final versionDir = cacheService.getVersionCacheDir(version);
 
-          final remoteResult = await runGitCommand(
-            ['remote', 'get-url', 'origin'],
-            workingDirectory: versionDir.path,
-          );
+          final remoteResult = await runGitCommand([
+            'remote',
+            'get-url',
+            'origin',
+          ], workingDirectory: versionDir.path);
 
           expect(remoteResult.stdout.toString().trim(), remoteDir.path);
 
           final alternatesFile = File(
-            p.join(
-              versionDir.path,
-              '.git',
-              'objects',
-              'info',
-              'alternates',
-            ),
+            p.join(versionDir.path, '.git', 'objects', 'info', 'alternates'),
           );
           expect(alternatesFile.existsSync(), isFalse);
         } finally {
@@ -298,146 +286,154 @@ void main() {
         }
       });
 
-      test('falls back to remote clone when local mirror is unavailable',
-          () async {
-        final tempDir = Directory.systemTemp.createTempSync(
-          'fvm_flutter_service_fallback_',
-        );
+      test(
+        'falls back to remote clone when local mirror is unavailable',
+        () async {
+          final tempDir = createTempDir('fvm_flutter_service_fallback');
 
-        try {
-          final remoteDir = await createLocalRemoteRepository(
-            root: tempDir,
-            name: 'flutter_origin',
-          );
+          try {
+            final remoteDir = await createLocalRemoteRepository(
+              root: tempDir,
+              name: 'flutter_origin',
+            );
 
-          final cachePath = p.join(tempDir.path, '.fvm');
-          final gitCachePath = p.join(tempDir.path, 'missing', 'mirror.git');
+            final cachePath = p.join(tempDir.path, '.fvm');
+            final gitCachePath = p.join(tempDir.path, 'missing', 'mirror.git');
 
-          final context = FvmContext.create(
-            isTest: true,
-            configOverrides: AppConfig(
-              cachePath: cachePath,
-              gitCachePath: gitCachePath,
-              flutterUrl: remoteDir.path,
-              useGitCache: true,
-            ),
-          );
+            final context = FvmContext.create(
+              isTest: true,
+              configOverrides: AppConfig(
+                cachePath: cachePath,
+                gitCachePath: gitCachePath,
+                flutterUrl: remoteDir.path,
+                useGitCache: true,
+              ),
+            );
 
-          final service = FlutterService(context);
-          final version = FlutterVersion.parse('master');
+            final service = FlutterService(context);
+            final version = FlutterVersion.parse('master');
 
-          await service.install(version);
+            await service.install(version);
 
-          final cacheService = context.get<CacheService>();
-          final versionDir = cacheService.getVersionCacheDir(version);
+            final cacheService = context.get<CacheService>();
+            final versionDir = cacheService.getVersionCacheDir(version);
 
-          final remoteResult = await runGitCommand(
-            ['remote', 'get-url', 'origin'],
-            workingDirectory: versionDir.path,
-          );
+            final remoteResult = await runGitCommand([
+              'remote',
+              'get-url',
+              'origin',
+            ], workingDirectory: versionDir.path);
 
-          expect(remoteResult.stdout.toString().trim(), remoteDir.path);
+            expect(remoteResult.stdout.toString().trim(), remoteDir.path);
 
-          final logger = context.get<Logger>();
-          expect(
-            logger.outputs.any(
-              (entry) => entry.contains('Falling back to remote clone'),
-            ),
-            isTrue,
-          );
-        } finally {
-          if (tempDir.existsSync()) {
-            tempDir.deleteSync(recursive: true);
+            final logger = context.get<Logger>();
+            expect(
+              logger.outputs.any(
+                (entry) => entry.contains('Falling back to remote clone'),
+              ),
+              isTrue,
+            );
+          } finally {
+            if (tempDir.existsSync()) {
+              tempDir.deleteSync(recursive: true);
+            }
           }
-        }
-      });
+        },
+      );
 
-      test('retries with remote clone when mirror is missing reference',
-          () async {
-        final tempDir = Directory.systemTemp.createTempSync(
-          'fvm_flutter_service_retry_',
-        );
+      test(
+        'retries with remote clone when mirror is missing reference',
+        () async {
+          final tempDir = createTempDir('fvm_flutter_service_retry');
 
-        try {
-          // Create remote and seed mirror before the new branch exists
-          final remoteDir = await createLocalRemoteRepository(
-            root: tempDir,
-            name: 'flutter_origin',
-          );
+          try {
+            // Create remote and seed mirror before the new branch exists
+            final remoteDir = await createLocalRemoteRepository(
+              root: tempDir,
+              name: 'flutter_origin',
+            );
 
-          final gitCachePath = p.join(tempDir.path, 'mirror.git');
-          Directory(gitCachePath).parent.createSync(recursive: true);
-          await runGitCommand([
-            'clone',
-            '--mirror',
-            remoteDir.path,
-            gitCachePath,
-          ]);
+            final gitCachePath = p.join(tempDir.path, 'mirror.git');
+            Directory(gitCachePath).parent.createSync(recursive: true);
+            await runGitCommand([
+              'clone',
+              '--mirror',
+              remoteDir.path,
+              gitCachePath,
+            ]);
 
-          // Add a new branch to the remote after the mirror was created so the
-          // mirror does not contain the reference.
-          final workDir = Directory(p.join(tempDir.path, 'work'))..createSync();
-          await runGitCommand(['clone', remoteDir.path, workDir.path]);
-          await runGitCommand(
-            ['config', 'user.email', 'tests@fvm.app'],
-            workingDirectory: workDir.path,
-          );
-          await runGitCommand(
-            ['config', 'user.name', 'FVM Tests'],
-            workingDirectory: workDir.path,
-          );
-          await runGitCommand(
-            ['checkout', '-b', 'feature'],
-            workingDirectory: workDir.path,
-          );
-          File(p.join(workDir.path, 'FEATURE.md')).writeAsStringSync('feature');
-          await runGitCommand(['add', '.'], workingDirectory: workDir.path);
-          await runGitCommand(
-            ['commit', '-m', 'Add feature branch'],
-            workingDirectory: workDir.path,
-          );
-          await runGitCommand(
-            ['push', 'origin', 'feature'],
-            workingDirectory: workDir.path,
-          );
+            // Add a new branch to the remote after the mirror was created so the
+            // mirror does not contain the reference.
+            final workDir = Directory(p.join(tempDir.path, 'work'))
+              ..createSync();
+            await runGitCommand(['clone', remoteDir.path, workDir.path]);
+            await runGitCommand([
+              'config',
+              'user.email',
+              'tests@fvm.app',
+            ], workingDirectory: workDir.path);
+            await runGitCommand([
+              'config',
+              'user.name',
+              'FVM Tests',
+            ], workingDirectory: workDir.path);
+            await runGitCommand([
+              'checkout',
+              '-b',
+              'feature',
+            ], workingDirectory: workDir.path);
+            File(
+              p.join(workDir.path, 'FEATURE.md'),
+            ).writeAsStringSync('feature');
+            await runGitCommand(['add', '.'], workingDirectory: workDir.path);
+            await runGitCommand([
+              'commit',
+              '-m',
+              'Add feature branch',
+            ], workingDirectory: workDir.path);
+            await runGitCommand([
+              'push',
+              'origin',
+              'feature',
+            ], workingDirectory: workDir.path);
 
-          final cachePath = p.join(tempDir.path, '.fvm');
+            final cachePath = p.join(tempDir.path, '.fvm');
 
-          final context = FvmContext.create(
-            isTest: true,
-            configOverrides: AppConfig(
-              cachePath: cachePath,
-              gitCachePath: gitCachePath,
-              flutterUrl: remoteDir.path,
-              useGitCache: true,
-            ),
-          );
+            final context = FvmContext.create(
+              isTest: true,
+              configOverrides: AppConfig(
+                cachePath: cachePath,
+                gitCachePath: gitCachePath,
+                flutterUrl: remoteDir.path,
+                useGitCache: true,
+              ),
+            );
 
-          final service = FlutterService(context);
-          final version = FlutterVersion.parse('feature');
+            final service = FlutterService(context);
+            final version = FlutterVersion.parse('feature');
 
-          await service.install(version);
+            await service.install(version);
 
-          final cacheService = context.get<CacheService>();
-          final versionDir = cacheService.getVersionCacheDir(version);
+            final cacheService = context.get<CacheService>();
+            final versionDir = cacheService.getVersionCacheDir(version);
 
-          final headResult = await runGitCommand(
-            ['rev-parse', '--abbrev-ref', 'HEAD'],
-            workingDirectory: versionDir.path,
-          );
+            final headResult = await runGitCommand([
+              'rev-parse',
+              '--abbrev-ref',
+              'HEAD',
+            ], workingDirectory: versionDir.path);
 
-          expect(headResult.stdout.toString().trim(), 'feature');
-        } finally {
-          if (tempDir.existsSync()) {
-            tempDir.deleteSync(recursive: true);
+            expect(headResult.stdout.toString().trim(), 'feature');
+          } finally {
+            if (tempDir.existsSync()) {
+              tempDir.deleteSync(recursive: true);
+            }
           }
-        }
-      });
+        },
+      );
 
       test('falls back to remote when mirror has missing objects', () async {
-        final tempDir = Directory.systemTemp.createTempSync(
-          'fvm_flutter_service_missing_objects_',
-        );
+        final tempDir = createTempDir('fvm_flutter_service_missing_objects');
 
         try {
           final remoteDir = await createLocalRemoteRepository(
@@ -448,28 +444,33 @@ void main() {
           // Create a feature branch in the remote.
           final workDir = Directory(p.join(tempDir.path, 'work'))..createSync();
           await runGitCommand(['clone', remoteDir.path, workDir.path]);
-          await runGitCommand(
-            ['config', 'user.email', 'tests@fvm.app'],
-            workingDirectory: workDir.path,
-          );
-          await runGitCommand(
-            ['config', 'user.name', 'FVM Tests'],
-            workingDirectory: workDir.path,
-          );
-          await runGitCommand(
-            ['checkout', '-b', 'feature'],
-            workingDirectory: workDir.path,
-          );
+          await runGitCommand([
+            'config',
+            'user.email',
+            'tests@fvm.app',
+          ], workingDirectory: workDir.path);
+          await runGitCommand([
+            'config',
+            'user.name',
+            'FVM Tests',
+          ], workingDirectory: workDir.path);
+          await runGitCommand([
+            'checkout',
+            '-b',
+            'feature',
+          ], workingDirectory: workDir.path);
           File(p.join(workDir.path, 'FEATURE.md')).writeAsStringSync('feature');
           await runGitCommand(['add', '.'], workingDirectory: workDir.path);
-          await runGitCommand(
-            ['commit', '-m', 'Add feature branch'],
-            workingDirectory: workDir.path,
-          );
-          await runGitCommand(
-            ['push', 'origin', 'feature'],
-            workingDirectory: workDir.path,
-          );
+          await runGitCommand([
+            'commit',
+            '-m',
+            'Add feature branch',
+          ], workingDirectory: workDir.path);
+          await runGitCommand([
+            'push',
+            'origin',
+            'feature',
+          ], workingDirectory: workDir.path);
 
           final gitCachePath = p.join(tempDir.path, 'mirror.git');
           Directory(gitCachePath).parent.createSync(recursive: true);
@@ -480,10 +481,10 @@ void main() {
             gitCachePath,
           ]);
 
-          final featureShaResult = await runGitCommand(
-            ['rev-parse', 'feature'],
-            workingDirectory: gitCachePath,
-          );
+          final featureShaResult = await runGitCommand([
+            'rev-parse',
+            'feature',
+          ], workingDirectory: gitCachePath);
           final featureSha = featureShaResult.stdout.toString().trim();
           await _deleteLooseGitObject(
             repoPath: gitCachePath,
@@ -508,10 +509,11 @@ void main() {
 
           final cacheService = context.get<CacheService>();
           final versionDir = cacheService.getVersionCacheDir(version);
-          final headResult = await runGitCommand(
-            ['rev-parse', '--abbrev-ref', 'HEAD'],
-            workingDirectory: versionDir.path,
-          );
+          final headResult = await runGitCommand([
+            'rev-parse',
+            '--abbrev-ref',
+            'HEAD',
+          ], workingDirectory: versionDir.path);
 
           expect(headResult.stdout.toString().trim(), 'feature');
         } finally {
@@ -641,10 +643,7 @@ void main() {
           directory: p.join(context.versionsCachePath, 'stable'),
         );
 
-        final result = await service.pubGet(
-          mockCacheVersion,
-          offline: true,
-        );
+        final result = await service.pubGet(mockCacheVersion, offline: true);
 
         expect(result.exitCode, equals(0));
         expect(processService.lastCommand, equals('flutter'));

--- a/test/services/git_clone_fallback_test.dart
+++ b/test/services/git_clone_fallback_test.dart
@@ -20,7 +20,7 @@ void main() {
     late List<CacheFlutterVersion> installedVersions;
 
     setUp(() async {
-      tempDir = Directory.systemTemp.createTempSync('fvm_git_cache_test_');
+      tempDir = createTempDir('fvm_git_cache_test');
 
       remoteDir = await createLocalRemoteRepository(
         root: tempDir,
@@ -52,75 +52,63 @@ void main() {
       }
     });
 
-    test(
-      'migrates working-tree cache to bare mirror',
-      () async {
-        Directory(context.gitCachePath).parent.createSync(recursive: true);
-        await runGitCommand(['clone', remoteDir.path, context.gitCachePath]);
+    test('migrates working-tree cache to bare mirror', () async {
+      Directory(context.gitCachePath).parent.createSync(recursive: true);
+      await runGitCommand(['clone', remoteDir.path, context.gitCachePath]);
 
-        final versionDir = Directory(
-          p.join(context.versionsCachePath, 'master'),
-        );
-        versionDir.parent.createSync(recursive: true);
+      final versionDir = Directory(p.join(context.versionsCachePath, 'master'));
+      versionDir.parent.createSync(recursive: true);
 
-        await runGitCommand([
-          'clone',
-          '--reference',
-          context.gitCachePath,
-          remoteDir.path,
-          versionDir.path,
-        ]);
+      await runGitCommand([
+        'clone',
+        '--reference',
+        context.gitCachePath,
+        remoteDir.path,
+        versionDir.path,
+      ]);
 
-        final version = FlutterVersion.parse('master');
-        installedVersions.add(
-          CacheFlutterVersion.fromVersion(version, directory: versionDir.path),
-        );
+      final version = FlutterVersion.parse('master');
+      installedVersions.add(
+        CacheFlutterVersion.fromVersion(version, directory: versionDir.path),
+      );
 
-        final alternatesFile = File(
-          p.join(
-            versionDir.path,
-            '.git',
-            'objects',
-            'info',
-            'alternates',
-          ),
-        );
-        expect(alternatesFile.existsSync(), isTrue);
+      final alternatesFile = File(
+        p.join(versionDir.path, '.git', 'objects', 'info', 'alternates'),
+      );
+      expect(alternatesFile.existsSync(), isTrue);
 
-        await gitService.updateLocalMirror();
+      await gitService.updateLocalMirror();
 
-        // After migration, the cache should be bare
-        expect(await isBareGitRepository(context.gitCachePath), isTrue);
+      // After migration, the cache should be bare
+      expect(await isBareGitRepository(context.gitCachePath), isTrue);
 
-        // Alternates file should still exist with path rewritten to bare mirror
-        expect(alternatesFile.existsSync(), isTrue);
-        final rawAlternates = alternatesFile.readAsStringSync().trim();
-        final resolvedAlternatesPath = p.isAbsolute(rawAlternates)
-            ? rawAlternates
-            : p.join(alternatesFile.parent.path, rawAlternates);
-        // Resolve symlinks (macOS /var -> /private/var) for reliable comparison
-        final resolvedAlternates = p.normalize(
-          Directory(resolvedAlternatesPath).existsSync()
-              ? Directory(resolvedAlternatesPath).resolveSymbolicLinksSync()
-              : resolvedAlternatesPath,
-        );
-        final expectedObjectsDir = Directory(
-          p.join(context.gitCachePath, 'objects'),
-        );
-        final expectedAlternates = p.normalize(
-          expectedObjectsDir.existsSync()
-              ? expectedObjectsDir.resolveSymbolicLinksSync()
-              : expectedObjectsDir.path,
-        );
-        expect(resolvedAlternates, expectedAlternates);
+      // Alternates file should still exist with path rewritten to bare mirror
+      expect(alternatesFile.existsSync(), isTrue);
+      final rawAlternates = alternatesFile.readAsStringSync().trim();
+      final resolvedAlternatesPath = p.isAbsolute(rawAlternates)
+          ? rawAlternates
+          : p.join(alternatesFile.parent.path, rawAlternates);
+      // Resolve symlinks (macOS /var -> /private/var) for reliable comparison
+      final resolvedAlternates = p.normalize(
+        Directory(resolvedAlternatesPath).existsSync()
+            ? Directory(resolvedAlternatesPath).resolveSymbolicLinksSync()
+            : resolvedAlternatesPath,
+      );
+      final expectedObjectsDir = Directory(
+        p.join(context.gitCachePath, 'objects'),
+      );
+      final expectedAlternates = p.normalize(
+        expectedObjectsDir.existsSync()
+            ? expectedObjectsDir.resolveSymbolicLinksSync()
+            : expectedObjectsDir.path,
+      );
+      expect(resolvedAlternates, expectedAlternates);
 
-        final legacyArtifacts = Directory(context.gitCachePath)
-            .parent
-            .listSync()
-            .where((entity) => entity.path.contains('.legacy-'));
-        expect(legacyArtifacts, isEmpty);
-      },
-    );
+      final legacyArtifacts = Directory(
+        context.gitCachePath,
+      ).parent.listSync().where((entity) => entity.path.contains('.legacy-'));
+      expect(legacyArtifacts, isEmpty);
+    });
 
     test(
       'does not rewrite alternates that point outside cache path boundary',
@@ -134,13 +122,7 @@ void main() {
         versionDir.createSync(recursive: true);
 
         final alternatesFile = File(
-          p.join(
-            versionDir.path,
-            '.git',
-            'objects',
-            'info',
-            'alternates',
-          ),
+          p.join(versionDir.path, '.git', 'objects', 'info', 'alternates'),
         )..createSync(recursive: true);
 
         final backupObjectsPath = p.join(

--- a/test/services/git_service_test.dart
+++ b/test/services/git_service_test.dart
@@ -108,10 +108,7 @@ void main() {
       const repoPath = '/tmp/fvm-test-repo';
       const url = 'https://example.com/flutter.git';
 
-      await gitService.setOriginUrl(
-        repositoryPath: repoPath,
-        url: url,
-      );
+      await gitService.setOriginUrl(repositoryPath: repoPath, url: url);
 
       expect(processService.lastCommand, equals('git'));
       expect(
@@ -127,7 +124,7 @@ void main() {
     late Directory remoteDir;
 
     setUp(() async {
-      tempDir = Directory.systemTemp.createTempSync('fvm_cache_state_test_');
+      tempDir = createTempDir('fvm_cache_state_test');
       remoteDir = await createLocalRemoteRepository(
         root: tempDir,
         name: 'flutter_remote',
@@ -228,23 +225,24 @@ void main() {
       expect(cacheDir.existsSync(), isFalse);
     });
 
-    test('waits for cache lock before running cache migration checks',
-        () async {
-      final gitCachePath = p.join(tempDir.path, 'cache.git');
-      final lockFilePath = '$gitCachePath.lock';
-      final context = FvmContext.create(
-        isTest: true,
-        configOverrides: AppConfig(
-          cachePath: p.join(tempDir.path, '.fvm'),
-          gitCachePath: gitCachePath,
-          flutterUrl: remoteDir.path,
-          useGitCache: true,
-        ),
-      );
+    test(
+      'waits for cache lock before running cache migration checks',
+      () async {
+        final gitCachePath = p.join(tempDir.path, 'cache.git');
+        final lockFilePath = '$gitCachePath.lock';
+        final context = FvmContext.create(
+          isTest: true,
+          configOverrides: AppConfig(
+            cachePath: p.join(tempDir.path, '.fvm'),
+            gitCachePath: gitCachePath,
+            flutterUrl: remoteDir.path,
+            useGitCache: true,
+          ),
+        );
 
-      final lockHelper = File(
-        p.join(tempDir.path, 'hold_git_cache_lock.dart'),
-      )..writeAsStringSync('''
+        final lockHelper =
+            File(p.join(tempDir.path, 'hold_git_cache_lock.dart'))
+              ..writeAsStringSync('''
 import 'dart:io';
 
 Future<void> main(List<String> args) async {
@@ -260,35 +258,36 @@ Future<void> main(List<String> args) async {
 }
 ''');
 
-      final lockProcess = await Process.start(Platform.resolvedExecutable, [
-        lockHelper.path,
-        lockFilePath,
-        '1200',
-      ]);
+        final lockProcess = await Process.start(Platform.resolvedExecutable, [
+          lockHelper.path,
+          lockFilePath,
+          '1200',
+        ]);
 
-      final lockReady = lockProcess.stdout
-          .transform(utf8.decoder)
-          .transform(const LineSplitter())
-          .firstWhere((line) => line.trim() == 'locked');
+        final lockReady = lockProcess.stdout
+            .transform(utf8.decoder)
+            .transform(const LineSplitter())
+            .firstWhere((line) => line.trim() == 'locked');
 
-      await lockReady.timeout(const Duration(seconds: 5));
+        await lockReady.timeout(const Duration(seconds: 5));
 
-      final gitService = GitService(context);
-      var completed = false;
-      final operation = gitService.ensureBareCacheIfPresent().then((_) {
-        completed = true;
-      });
+        final gitService = GitService(context);
+        var completed = false;
+        final operation = gitService.ensureBareCacheIfPresent().then((_) {
+          completed = true;
+        });
 
-      await Future<void>.delayed(const Duration(milliseconds: 250));
-      expect(completed, isFalse);
+        await Future<void>.delayed(const Duration(milliseconds: 250));
+        expect(completed, isFalse);
 
-      final lockExitCode = await lockProcess.exitCode.timeout(
-        const Duration(seconds: 5),
-      );
-      expect(lockExitCode, 0);
+        final lockExitCode = await lockProcess.exitCode.timeout(
+          const Duration(seconds: 5),
+        );
+        expect(lockExitCode, 0);
 
-      await operation.timeout(const Duration(seconds: 5));
-      expect(completed, isTrue);
-    });
+        await operation.timeout(const Duration(seconds: 5));
+        expect(completed, isTrue);
+      },
+    );
   });
 }

--- a/test/src/models/cache_flutter_version_model_test.dart
+++ b/test/src/models/cache_flutter_version_model_test.dart
@@ -4,6 +4,8 @@ import 'package:fvm/fvm.dart';
 import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
 
+import '../../testing_utils.dart';
+
 void main() {
   group('CacheFlutterVersion', () {
     test('fromMap constructor', () {
@@ -113,7 +115,7 @@ void main() {
 
     test('flutterSdkVersion getter', () {
       // Create a temporary directory for testing
-      final tempDir = Directory.systemTemp.createTempSync('cache_version_test');
+      final tempDir = createTempDir('cache_version_test');
       final versionFile = File(path.join(tempDir.path, 'version'));
       versionFile.writeAsStringSync('1.0.0');
 
@@ -128,78 +130,86 @@ void main() {
     });
 
     test(
-        'flutterSdkVersion returns null when no json or legacy version file present',
-        () {
-      final tempDir = Directory.systemTemp.createTempSync('cache_version_test');
-      // Simulate artifacts existing (dart-sdk/version) so we don't rely on git.
-      final dartSdkDir =
-          Directory(path.join(tempDir.path, 'bin', 'cache', 'dart-sdk'))
-            ..createSync(recursive: true);
-      File(path.join(dartSdkDir.path, 'version')).writeAsStringSync('3.9.0');
+      'flutterSdkVersion returns null when no json or legacy version file present',
+      () {
+        final tempDir = createTempDir('cache_version_test');
+        // Simulate artifacts existing (dart-sdk/version) so we don't rely on git.
+        final dartSdkDir = Directory(
+          path.join(tempDir.path, 'bin', 'cache', 'dart-sdk'),
+        )..createSync(recursive: true);
+        File(path.join(dartSdkDir.path, 'version')).writeAsStringSync('3.9.0');
 
-      final version = CacheFlutterVersion.fromVersion(
-        FlutterVersion.release('test'),
-        directory: tempDir.path,
-      );
+        final version = CacheFlutterVersion.fromVersion(
+          FlutterVersion.release('test'),
+          directory: tempDir.path,
+        );
 
-      expect(version.flutterSdkVersion, isNull);
+        expect(version.flutterSdkVersion, isNull);
 
-      tempDir.deleteSync(recursive: true);
-    });
+        tempDir.deleteSync(recursive: true);
+      },
+    );
 
     test(
-        'flutterSdkVersion reads flutter.version.json when legacy file missing',
-        () {
-      final tempDir = Directory.systemTemp.createTempSync('cache_version_test');
-      final jsonFile = File(
-        path.join(tempDir.path, 'bin', 'cache', 'flutter.version.json'),
-      )..createSync(recursive: true);
+      'flutterSdkVersion reads flutter.version.json when legacy file missing',
+      () {
+        final tempDir = createTempDir('cache_version_test');
+        final jsonFile = File(
+          path.join(tempDir.path, 'bin', 'cache', 'flutter.version.json'),
+        )..createSync(recursive: true);
 
-      final fixture =
-          File(path.join('test', 'fixtures', 'flutter.version.example.json'));
-      expect(fixture.existsSync(), isTrue,
-          reason: 'Fixture flutter.version.example.json is missing');
-      jsonFile.writeAsStringSync(fixture.readAsStringSync());
+        final fixture = File(
+          path.join('test', 'fixtures', 'flutter.version.example.json'),
+        );
+        expect(
+          fixture.existsSync(),
+          isTrue,
+          reason: 'Fixture flutter.version.example.json is missing',
+        );
+        jsonFile.writeAsStringSync(fixture.readAsStringSync());
 
-      final version = CacheFlutterVersion.fromVersion(
-        FlutterVersion.release('test'),
-        directory: tempDir.path,
-      );
+        final version = CacheFlutterVersion.fromVersion(
+          FlutterVersion.release('test'),
+          directory: tempDir.path,
+        );
 
-      expect(version.flutterSdkVersion, '3.33.0-1.0.pre-1070');
+        expect(version.flutterSdkVersion, '3.33.0-1.0.pre-1070');
 
-      tempDir.deleteSync(recursive: true);
-    });
+        tempDir.deleteSync(recursive: true);
+      },
+    );
 
     test('dartSdkVersion getter prefers flutter.version.json when present', () {
-      final tempDir = Directory.systemTemp.createTempSync('cache_version_test');
+      final tempDir = createTempDir('cache_version_test');
       final jsonFile = File(
         path.join(tempDir.path, 'bin', 'cache', 'flutter.version.json'),
       )..createSync(recursive: true);
 
-      final fixture =
-          File(path.join('test', 'fixtures', 'flutter.version.example.json'));
-      expect(fixture.existsSync(), isTrue,
-          reason: 'Fixture flutter.version.example.json is missing');
+      final fixture = File(
+        path.join('test', 'fixtures', 'flutter.version.example.json'),
+      );
+      expect(
+        fixture.existsSync(),
+        isTrue,
+        reason: 'Fixture flutter.version.example.json is missing',
+      );
       jsonFile.writeAsStringSync(fixture.readAsStringSync());
 
       final version = CacheFlutterVersion.fromVersion(
         FlutterVersion.release('test'),
         directory: tempDir.path,
       );
-      expect(
-        version.dartSdkVersion,
-        '3.10.0 (build 3.10.0-15.0.dev)',
-      );
+      expect(version.dartSdkVersion, '3.10.0 (build 3.10.0-15.0.dev)');
 
       tempDir.deleteSync(recursive: true);
     });
 
     test('dartSdkVersion getter', () {
       // Create a temporary directory for testing
-      final tempDir = Directory.systemTemp.createTempSync('cache_version_test');
-      final dartSdkDir =
-          Directory(path.join(tempDir.path, 'bin', 'cache', 'dart-sdk'));
+      final tempDir = createTempDir('cache_version_test');
+      final dartSdkDir = Directory(
+        path.join(tempDir.path, 'bin', 'cache', 'dart-sdk'),
+      );
       dartSdkDir.createSync(recursive: true);
       final versionFile = File(path.join(dartSdkDir.path, 'version'));
       versionFile.writeAsStringSync('2.12.0');
@@ -224,14 +234,15 @@ void main() {
 
     test('isSetup getter', () {
       // Create a temporary directory for testing
-      final tempDir = Directory.systemTemp.createTempSync('cache_version_test');
+      final tempDir = createTempDir('cache_version_test');
       // isSetup now checks for dart-sdk/bin/ directory existence (more robust)
-      final dartSdkBinDir =
-          Directory(path.join(tempDir.path, 'bin', 'cache', 'dart-sdk', 'bin'))
-            ..createSync(recursive: true);
+      final dartSdkBinDir = Directory(
+        path.join(tempDir.path, 'bin', 'cache', 'dart-sdk', 'bin'),
+      )..createSync(recursive: true);
       // Also create version file so dartSdkVersion is populated
-      File(path.join(dartSdkBinDir.parent.path, 'version'))
-          .writeAsStringSync('3.9.0');
+      File(
+        path.join(dartSdkBinDir.parent.path, 'version'),
+      ).writeAsStringSync('3.9.0');
 
       final version = CacheFlutterVersion.fromVersion(
         FlutterVersion.release('test'),
@@ -245,7 +256,7 @@ void main() {
     });
 
     test('flutterSdkVersion is null when no version sources available', () {
-      final tempDir = Directory.systemTemp.createTempSync('no_version_');
+      final tempDir = createTempDir('no_version');
 
       final version = CacheFlutterVersion.fromVersion(
         FlutterVersion.parse('test'),

--- a/test/src/models/flutter_root_version_file_test.dart
+++ b/test/src/models/flutter_root_version_file_test.dart
@@ -4,11 +4,16 @@ import 'package:fvm/src/models/flutter_root_version_file.dart';
 import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
 
+import '../../testing_utils.dart';
+
 void main() {
   group('FlutterRootVersionFile', () {
     test('parses sample file', () {
-      final fixturePath =
-          path.join('test', 'fixtures', 'flutter.version.example.json');
+      final fixturePath = path.join(
+        'test',
+        'fixtures',
+        'flutter.version.example.json',
+      );
       final file = File(fixturePath);
       expect(file.existsSync(), isTrue);
 
@@ -20,8 +25,9 @@ void main() {
     });
 
     test('falls back to frameworkVersion when flutterVersion missing', () {
-      final metadata =
-          FlutterRootVersionFile.fromMap({'frameworkVersion': '3.2.0'});
+      final metadata = FlutterRootVersionFile.fromMap({
+        'frameworkVersion': '3.2.0',
+      });
 
       expect(metadata.primaryVersion, '3.2.0');
     });
@@ -35,7 +41,7 @@ void main() {
     });
 
     test('returns null for malformed JSON', () {
-      final tempDir = Directory.systemTemp.createTempSync('malformed_');
+      final tempDir = createTempDir('malformed');
       final file = File(path.join(tempDir.path, 'flutter.version.json'));
       file.writeAsStringSync('{ invalid json }');
 
@@ -45,7 +51,7 @@ void main() {
     });
 
     test('returns null for JSON array instead of object', () {
-      final tempDir = Directory.systemTemp.createTempSync('array_');
+      final tempDir = createTempDir('array');
       final file = File(path.join(tempDir.path, 'flutter.version.json'));
       file.writeAsStringSync('["3.0.0"]');
 
@@ -55,7 +61,7 @@ void main() {
     });
 
     test('returns null for empty file', () {
-      final tempDir = Directory.systemTemp.createTempSync('empty_');
+      final tempDir = createTempDir('empty');
       final file = File(path.join(tempDir.path, 'flutter.version.json'));
       file.writeAsStringSync('');
 

--- a/test/testing_helpers/prepare_test_environment.dart
+++ b/test/testing_helpers/prepare_test_environment.dart
@@ -5,8 +5,17 @@ import 'package:fvm/src/utils/context.dart';
 import 'package:io/io.dart';
 import 'package:path/path.dart';
 
+const _kSharedTestCacheDirName = 'fvm_test_cache';
+const _kSharedTestWorkspaceDirName = 'workspaces';
+
 String getTempTestDir([String? contextId = '', String path = '']) {
-  return join(kUserHome, 'fvm-test', contextId, path);
+  return join(
+    kUserHome,
+    _kSharedTestCacheDirName,
+    _kSharedTestWorkspaceDirName,
+    contextId,
+    path,
+  );
 }
 
 String getTempTestProjectDir([String? contextId = '', String name = '']) {
@@ -67,16 +76,16 @@ Future<void> setUpContext(
 }
 
 void tearDownContext(FvmContext context) {
-  // final tempPath = getTempTestDir(context.id);
+  final tempPath = getTempTestDir(context.debugLabel);
 
-  // final tempDir = Directory(tempPath);
+  final tempDir = Directory(tempPath);
 
-  // if (tempDir.existsSync()) {
-  //   try {
-  //     tempDir.deleteSync(recursive: true);
-  //   } on FileSystemException catch (e) {
-  //     // just log the error, as it can fail due to open files
-  //     logger.err(e.message);
-  //   }
-  // }
+  if (!tempDir.existsSync()) return;
+
+  try {
+    tempDir.deleteSync(recursive: true);
+  } on FileSystemException {
+    // Best-effort cleanup: tests should not fail only because the OS still has
+    // a handle open on a file inside the fixture workspace.
+  }
 }

--- a/test/testing_utils.dart
+++ b/test/testing_utils.dart
@@ -44,11 +44,186 @@ void forceUpdateFlutterSdkVersionFile(
 }
 
 const _kTempTestDirPrefix = 'TEST_DIR_';
+const _kManagedTempRootPrefix = '${_kTempTestDirPrefix}fvm_';
+const _kManagedTempRootMarker = '.fvm_test_temp_root.json';
+const _kLegacySystemTempStaleAge = Duration(hours: 4);
+
+final _testTempDirectoryManager = _TestTempDirectoryManager();
 
 Directory createTempDir([String prefix = '']) {
-  prefix = prefix.isEmpty ? '' : '_$prefix';
+  return _testTempDirectoryManager.create(prefix);
+}
 
-  return Directory.systemTemp.createTempSync('$_kTempTestDirPrefix$prefix');
+int cleanUpStaleFvmTestTempDirs({
+  Directory? tempRoot,
+  Directory? currentRoot,
+  DateTime? createdBefore,
+}) {
+  return _TestTempDirectoryManager.cleanUpStale(
+    tempRoot: tempRoot,
+    currentRoot: currentRoot,
+    createdBefore: createdBefore,
+  );
+}
+
+class _TestTempDirectoryManager {
+  final DateTime _createdAt = DateTime.now();
+
+  Directory? _root;
+  bool _staleDirsCleaned = false;
+
+  Directory create(String prefix) {
+    final root = _ensureRoot();
+    final dir = root.createTempSync(_childPrefix(prefix));
+    _registerCleanup(() => _tryDeleteDirectory(dir));
+
+    return dir;
+  }
+
+  static int cleanUpStale({
+    Directory? tempRoot,
+    Directory? currentRoot,
+    DateTime? createdBefore,
+  }) {
+    final root = tempRoot ?? Directory.systemTemp;
+    if (!root.existsSync()) return 0;
+
+    var removed = 0;
+    final cutoff = createdBefore ?? DateTime.now();
+
+    for (final entity in root.listSync(followLinks: false)) {
+      if (entity is! Directory) continue;
+      if (!_isOwnedTestTempDir(root, entity)) continue;
+      if (currentRoot != null && p.equals(entity.path, currentRoot.path)) {
+        continue;
+      }
+      if (_isActiveManagedRoot(entity)) continue;
+
+      final DateTime modified;
+      try {
+        modified = entity.statSync().modified;
+      } on FileSystemException {
+        continue;
+      }
+      if (!modified.isBefore(cutoff)) continue;
+
+      if (_tryDeleteDirectory(entity)) {
+        removed++;
+      }
+    }
+
+    return removed;
+  }
+
+  Directory _ensureRoot() {
+    final currentRoot = _root;
+    if (currentRoot != null && currentRoot.existsSync()) return currentRoot;
+
+    final tempRoot = _sharedTempDir;
+    tempRoot.createSync(recursive: true);
+
+    final root = tempRoot.createTempSync(_kManagedTempRootPrefix);
+    _root = root;
+    _writeMarker(root);
+    _registerCleanup(() {
+      _tryDeleteDirectory(root);
+      if (_root != null && p.equals(_root!.path, root.path)) {
+        _root = null;
+      }
+    });
+
+    if (!_staleDirsCleaned) {
+      _staleDirsCleaned = true;
+      cleanUpStale(
+        tempRoot: tempRoot,
+        currentRoot: root,
+        createdBefore: _createdAt,
+      );
+      cleanUpStale(
+        tempRoot: Directory.systemTemp,
+        // Legacy TEST_DIR_* roots have no marker file, so give active old-style
+        // test runs a grace period before reaping their directories.
+        createdBefore: _createdAt.subtract(_kLegacySystemTempStaleAge),
+      );
+    }
+
+    return root;
+  }
+
+  void _registerCleanup(void Function() callback) {
+    try {
+      addTearDown(callback);
+    } on StateError {
+      tearDownAll(callback);
+    }
+  }
+
+  void _writeMarker(Directory root) {
+    final marker = File(p.join(root.path, _kManagedTempRootMarker));
+    marker.writeAsStringSync(
+      jsonEncode({
+        'pid': pid,
+        'createdAt': DateTime.now().toUtc().toIso8601String(),
+      }),
+    );
+  }
+
+  static String _childPrefix(String prefix) {
+    final rawPrefix = prefix.isEmpty ? 'dir' : prefix;
+    final safePrefix = rawPrefix.replaceAll(RegExp(r'[^A-Za-z0-9_.-]'), '_');
+
+    return '${safePrefix}_';
+  }
+
+  static bool _isOwnedTestTempDir(Directory tempRoot, Directory dir) {
+    final rootPath = p.normalize(tempRoot.path);
+    final dirPath = p.normalize(dir.path);
+    final name = p.basename(dirPath);
+
+    return name.startsWith(_kTempTestDirPrefix) &&
+        p.equals(p.dirname(dirPath), rootPath);
+  }
+
+  static bool _isActiveManagedRoot(Directory dir) {
+    final marker = File(p.join(dir.path, _kManagedTempRootMarker));
+    if (!marker.existsSync()) return false;
+
+    try {
+      final decoded = jsonDecode(marker.readAsStringSync());
+      if (decoded is! Map<String, dynamic>) return false;
+      final ownerPid = decoded['pid'];
+      final ownerPidValue =
+          ownerPid is int ? ownerPid : int.tryParse(ownerPid?.toString() ?? '');
+      if (ownerPidValue == null) return false;
+
+      return _isProcessAlive(ownerPidValue);
+    } on FormatException {
+      return false;
+    } on FileSystemException {
+      return false;
+    }
+  }
+
+  static bool _isProcessAlive(int ownerPid) {
+    if (ownerPid == pid) return true;
+    if (Platform.isWindows) return true;
+
+    final result = Process.runSync('kill', ['-0', '$ownerPid']);
+
+    return result.exitCode == 0;
+  }
+
+  static bool _tryDeleteDirectory(Directory dir) {
+    if (!dir.existsSync()) return true;
+
+    try {
+      dir.deleteSync(recursive: true);
+
+      return true;
+    } on FileSystemException {
+      return false;
+    }
+  }
 }
 
 File createPubspecYaml(
@@ -307,9 +482,7 @@ class TempDirectoryTracker {
 
   void cleanUp() {
     for (final dir in _dirs) {
-      if (dir.existsSync()) {
-        dir.deleteSync(recursive: true);
-      }
+      _TestTempDirectoryManager._tryDeleteDirectory(dir);
     }
     _dirs.clear();
   }
@@ -355,28 +528,39 @@ Future<Directory> createLocalRemoteRepository({
 
   try {
     await runGitCommand(['init'], workingDirectory: seedDir.path);
-    await runGitCommand(
-      ['config', 'user.email', 'tests@fvm.app'],
-      workingDirectory: seedDir.path,
-    );
-    await runGitCommand(
-      ['config', 'user.name', 'FVM Tests'],
-      workingDirectory: seedDir.path,
-    );
+    await runGitCommand([
+      'config',
+      'user.email',
+      'tests@fvm.app',
+    ], workingDirectory: seedDir.path);
+    await runGitCommand([
+      'config',
+      'user.name',
+      'FVM Tests',
+    ], workingDirectory: seedDir.path);
     File(p.join(seedDir.path, 'README.md')).writeAsStringSync('seed data');
     await runGitCommand(['add', '.'], workingDirectory: seedDir.path);
-    await runGitCommand(['commit', '-m', 'seed'],
-        workingDirectory: seedDir.path);
-    await runGitCommand(['branch', '-M', branch],
-        workingDirectory: seedDir.path);
-    await runGitCommand(
-      ['remote', 'add', 'origin', remoteDir.path],
-      workingDirectory: seedDir.path,
-    );
-    await runGitCommand(
-      ['push', 'origin', branch],
-      workingDirectory: seedDir.path,
-    );
+    await runGitCommand([
+      'commit',
+      '-m',
+      'seed',
+    ], workingDirectory: seedDir.path);
+    await runGitCommand([
+      'branch',
+      '-M',
+      branch,
+    ], workingDirectory: seedDir.path);
+    await runGitCommand([
+      'remote',
+      'add',
+      'origin',
+      remoteDir.path,
+    ], workingDirectory: seedDir.path);
+    await runGitCommand([
+      'push',
+      'origin',
+      branch,
+    ], workingDirectory: seedDir.path);
   } finally {
     if (seedDir.existsSync()) {
       seedDir.deleteSync(recursive: true);
@@ -387,10 +571,10 @@ Future<Directory> createLocalRemoteRepository({
 }
 
 Future<bool> isBareGitRepository(String repoPath) async {
-  final result = await runGitCommand(
-    ['rev-parse', '--is-bare-repository'],
-    workingDirectory: repoPath,
-  );
+  final result = await runGitCommand([
+    'rev-parse',
+    '--is-bare-repository',
+  ], workingDirectory: repoPath);
 
   return result.stdout.toString().trim() == 'true';
 }
@@ -404,6 +588,7 @@ class MockFlutterService extends FlutterService {
 }
 
 final _sharedTestFvmDir = Directory(p.join(kUserHome, 'fvm_test_cache'));
+final _sharedTempDir = Directory(p.join(_sharedTestFvmDir.path, 'tmp'));
 final _sharedGitCacheDir = Directory(
   p.join(_sharedTestFvmDir.path, 'gitcache'),
 );

--- a/test/testing_utils.dart
+++ b/test/testing_utils.dart
@@ -391,9 +391,14 @@ class TestFactory {
     debugLabel ??= _generateUuid();
 
     final globalConfig = LocalAppConfig.read();
+    final contextRoot = createTempDir(debugLabel);
+    final cacheDir = Directory(p.join(contextRoot.path, 'cache'))
+      ..createSync(recursive: true);
+    final workingDir = Directory(p.join(contextRoot.path, 'workspace'))
+      ..createSync(recursive: true);
 
     final config = AppConfig(
-      cachePath: createTempDir().path,
+      cachePath: cacheDir.path,
       gitCachePath: _sharedGitCacheDir.path,
       privilegedAccess: privilegedAccess,
       useGitCache: true,
@@ -404,7 +409,7 @@ class TestFactory {
       debugLabel: debugLabel,
       configOverrides: config,
       logLevel: Level.verbose,
-      workingDirectoryOverride: createTempDir(debugLabel).path,
+      workingDirectoryOverride: workingDir.path,
       isTest: true,
       skipInput: skipInput ?? false,
       environmentOverrides: environmentOverrides,

--- a/test/testing_utils_test.dart
+++ b/test/testing_utils_test.dart
@@ -52,6 +52,20 @@ void main() {
       File(p.join(dir.path, 'payload.txt')).writeAsStringSync('data');
     });
 
+    test('TestFactory.context uses one temp root for cache and workspace', () {
+      final context = TestFactory.context(debugLabel: 'context_layout');
+      final cacheDir = Directory(context.fvmDir);
+      final workspaceDir = Directory(context.workingDirectory);
+      final contextRoot = p.dirname(cacheDir.path);
+
+      expect(cacheDir.existsSync(), isTrue);
+      expect(workspaceDir.existsSync(), isTrue);
+      expect(p.basename(cacheDir.path), 'cache');
+      expect(p.basename(workspaceDir.path), 'workspace');
+      expect(p.dirname(workspaceDir.path), contextRoot);
+      expect(p.basename(contextRoot), startsWith('context_layout_'));
+    });
+
     test('stale cleanup deletes only direct TEST_DIR children', () {
       final tempRoot = createTempDir('stale_cleanup_fixture');
       final staleDir = Directory(p.join(tempRoot.path, 'TEST_DIR_legacy'))

--- a/test/testing_utils_test.dart
+++ b/test/testing_utils_test.dart
@@ -1,0 +1,95 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:fvm/src/utils/constants.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+import 'testing_helpers/prepare_test_environment.dart';
+import 'testing_utils.dart';
+
+void main() {
+  group('shared FVM test cache layout', () {
+    test('older test workspace helpers use the shared cache root', () {
+      expect(
+        getTempTestDir(),
+        p.join(kUserHome, 'fvm_test_cache', 'workspaces'),
+      );
+      expect(
+        getTempTestProjectDir('context-a', 'app'),
+        p.join(
+          kUserHome,
+          'fvm_test_cache',
+          'workspaces',
+          'context-a',
+          'projects',
+          'app',
+        ),
+      );
+    });
+  });
+
+  group('test temp directories', () {
+    test('createTempDir registers cleanup with the current test', () {
+      late Directory dir;
+      late Directory root;
+
+      addTearDown(() {
+        expect(dir.existsSync(), isFalse);
+        expect(root.existsSync(), isFalse);
+      });
+
+      dir = createTempDir('registered_cleanup');
+      root = Directory(p.dirname(dir.path));
+
+      expect(dir.existsSync(), isTrue);
+      expect(p.basename(root.path), startsWith('TEST_DIR_fvm_'));
+      expect(
+        p.isWithin(p.join(kUserHome, 'fvm_test_cache', 'tmp'), root.path),
+        isTrue,
+      );
+
+      File(p.join(dir.path, 'payload.txt')).writeAsStringSync('data');
+    });
+
+    test('stale cleanup deletes only direct TEST_DIR children', () {
+      final tempRoot = createTempDir('stale_cleanup_fixture');
+      final staleDir = Directory(p.join(tempRoot.path, 'TEST_DIR_legacy'))
+        ..createSync();
+      final unrelatedDir = Directory(p.join(tempRoot.path, 'fvm_test_data'))
+        ..createSync();
+      final nestedOwnedDir = Directory(
+        p.join(unrelatedDir.path, 'TEST_DIR_nested'),
+      )..createSync();
+
+      File(p.join(staleDir.path, 'payload.txt')).writeAsStringSync('data');
+
+      final removed = cleanUpStaleFvmTestTempDirs(
+        tempRoot: tempRoot,
+        createdBefore: DateTime.now().add(const Duration(seconds: 1)),
+      );
+
+      expect(removed, 1);
+      expect(staleDir.existsSync(), isFalse);
+      expect(unrelatedDir.existsSync(), isTrue);
+      expect(nestedOwnedDir.existsSync(), isTrue);
+    });
+
+    test('stale cleanup keeps active managed roots', () {
+      final tempRoot = createTempDir('active_root_fixture');
+      final activeRoot = Directory(p.join(tempRoot.path, 'TEST_DIR_fvm_active'))
+        ..createSync();
+      File(
+        p.join(activeRoot.path, '.fvm_test_temp_root.json'),
+      ).writeAsStringSync(jsonEncode({'pid': pid}));
+
+      final removed = cleanUpStaleFvmTestTempDirs(
+        tempRoot: tempRoot,
+        createdBefore: DateTime.now().add(const Duration(seconds: 1)),
+      );
+
+      expect(removed, 0);
+      expect(activeRoot.existsSync(), isTrue);
+    });
+  });
+}

--- a/tool/release_tool/test/grind_test.dart
+++ b/tool/release_tool/test/grind_test.dart
@@ -11,6 +11,11 @@ void main() {
 
   setUp(() async {
     tempRepo = await Directory.systemTemp.createTemp('release_tool_test_');
+    addTearDown(() async {
+      if (await tempRepo.exists()) {
+        await tempRepo.delete(recursive: true);
+      }
+    });
     grind.repoRootOverride = tempRepo;
     grind.httpRequestOverride = null;
   });
@@ -26,15 +31,9 @@ void main() {
   group('getReleases', () {
     test('writes releases.txt for well-formed response', () async {
       grind.httpRequestOverride = (_) async => jsonEncode([
-            {
-              'tag_name': 'v1.0.0',
-              'published_at': '2024-01-01T00:00:00Z',
-            },
-            {
-              'tag_name': 'v0.9.0',
-              'published_at': '2023-12-01T00:00:00Z',
-            },
-          ]);
+        {'tag_name': 'v1.0.0', 'published_at': '2024-01-01T00:00:00Z'},
+        {'tag_name': 'v0.9.0', 'published_at': '2023-12-01T00:00:00Z'},
+      ]);
 
       await grind.getReleases();
 
@@ -47,17 +46,15 @@ void main() {
 
     test('skips releases missing required fields', () async {
       grind.httpRequestOverride = (_) async => jsonEncode([
-            {'tag_name': 'v1.0.0'},
-            {
-              'tag_name': 'v0.9.0',
-              'published_at': '2023-12-01T00:00:00Z',
-            },
-          ]);
+        {'tag_name': 'v1.0.0'},
+        {'tag_name': 'v0.9.0', 'published_at': '2023-12-01T00:00:00Z'},
+      ]);
 
       await grind.getReleases();
 
-      final contents =
-          File(p.join(tempRepo.path, 'releases.txt')).readAsStringSync();
+      final contents = File(
+        p.join(tempRepo.path, 'releases.txt'),
+      ).readAsStringSync();
       expect(contents, isNot(contains('v1.0.0')));
       expect(contents, contains('v0.9.0'));
     });
@@ -65,10 +62,7 @@ void main() {
     test('fails on invalid json', () async {
       grind.httpRequestOverride = (_) async => 'not-json';
 
-      await expectLater(
-        grind.getReleases(),
-        throwsA(isA<GrinderException>()),
-      );
+      await expectLater(grind.getReleases(), throwsA(isA<GrinderException>()));
     });
   });
 


### PR DESCRIPTION
## Summary

- Route FVM test temp directories through a managed `~/fvm_test_cache/tmp` root with teardown cleanup.
- Keep durable test assets separated under `~/fvm_test_cache/gitcache` and move older workspace fixtures to `~/fvm_test_cache/workspaces`.
- Add safe stale cleanup for clearly-owned `TEST_DIR_*` folders and regression coverage for cleanup behavior.
- Register cleanup for package-specific temp directories in the MCP and release-tool tests.

## Validation

- `dart analyze --fatal-infos`
- `dart test test/testing_utils_test.dart`
- `dart test test/testing_utils_test.dart test/src/models/cache_flutter_version_model_test.dart test/src/models/flutter_root_version_file_test.dart test/services/git_clone_fallback_test.dart test/services/git_service_test.dart test/services/flutter_service_test.dart`
- `dart test --concurrency=1 test/commands/enhanced_install_test.dart test/services/cache_service_test.dart test/integration/migration_from_v3_test.dart`
- `(cd fvm_mcp && dart test)`
- `(cd tool/release_tool && dart test)`
- `git diff --check`
- Final temp scan: OS `TEST_DIR_*` count `0`, shared `~/fvm_test_cache/tmp/TEST_DIR_*` count `0`, shared temp size `0B`.
