### PR TITLE
chore: prepare v4.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-## Unreleased
+## 4.1.1
 
-* fix: avoid false cache version mismatches from parent git tags (#1030)
-* fix: treat non-interactive stdin as skipped input so prompts use safe defaults instead of blocking.
+* fix: prevent git cache bloat and stale SDK installs caused by outdated cache clones (#1037)
+* fix: fall back to safe defaults instead of hanging when prompts run without an interactive terminal, like CI or git hooks (#1036)
+* fix: stop false Flutter version-mismatch prompts when a project uses its own calendar-style git tags (#1033)
 
 ## 4.1.0
 

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '4.1.0';
+const packageVersion = '4.1.1';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: fvm
 description: A simple cli to manage Flutter SDK versions per project. Support
   channels, releases, and local cache for fast switching between versions.
-version: 4.1.0
+version: 4.1.1
 homepage: https://github.com/leoafarias/fvm
 
 environment:


### PR DESCRIPTION
Patch release bundling the fixes merged since v4.1.0 (all `fix`/`chore` — no features, so semver patch).

## Changelog

* fix: prevent git cache bloat and stale SDK installs caused by outdated cache clones (#1037)
* fix: fall back to safe defaults instead of hanging when prompts run without an interactive terminal, like CI or git hooks (#1036)
* fix: stop false Flutter version-mismatch prompts when a project uses its own calendar-style git tags (#1033)

## Prep

- Bumped `version` to `4.1.1` in `pubspec.yaml` and `lib/src/version.dart`
- Rewrote the `Unreleased` changelog section into a clean `4.1.1` entry (repointed the version-mismatch item from issue #1030 to its fixing PR #1033)

Internal-only chores (test infra #1032/#1034, orphaned-README cleanup #1035, format/fix passes #1039/#1040) were intentionally left out of the changelog to keep it concise.

Merging this, then tagging `v4.1.1`, triggers the deploy workflow (pub.dev, GitHub release, Homebrew, Chocolatey, Docker).