### PR TITLE
fix: prevent needless git cache recreation from OS metadata files in refs (#1043)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* fix: stop rebuilding the git cache on every command when macOS leaves `.DS_Store` files in it (#1043)
+
 ## 4.1.1
 
 * fix: prevent git cache bloat and stale SDK installs caused by outdated cache clones (#1037)

--- a/lib/src/services/git_service.dart
+++ b/lib/src/services/git_service.dart
@@ -304,21 +304,28 @@ class GitService extends ContextualService {
     for (final refsDir in refsDirs) {
       if (!refsDir.existsSync()) continue;
 
-      await for (final entity
-          in refsDir.list(recursive: true, followLinks: false)) {
-        if (entity is! File) continue;
-        if (!_osMetadataFileNames.contains(path.basename(entity.path))) {
-          continue;
+      try {
+        await for (final entity
+            in refsDir.list(recursive: true, followLinks: false)) {
+          if (entity is! File) continue;
+          if (!_osMetadataFileNames.contains(path.basename(entity.path))) {
+            continue;
+          }
+          try {
+            entity.deleteSync();
+            logger.debug('Removed OS metadata file: ${entity.path}');
+          } on FileSystemException catch (error) {
+            logger.debug(
+              'Could not remove OS metadata file ${entity.path}: '
+              '${error.message}',
+            );
+          }
         }
-        try {
-          entity.deleteSync();
-          logger.debug('Removed OS metadata file: ${entity.path}');
-        } on FileSystemException catch (error) {
-          logger.debug(
-            'Could not remove OS metadata file ${entity.path}: '
-            '${error.message}',
-          );
-        }
+      } on FileSystemException catch (error) {
+        logger.debug(
+          'Could not scan refs directory ${refsDir.path} for OS metadata: '
+          '${error.message}',
+        );
       }
     }
   }

--- a/lib/src/services/git_service.dart
+++ b/lib/src/services/git_service.dart
@@ -32,6 +32,10 @@ class GitService extends ContextualService {
   );
   static const Duration _staleGitCacheTempAge = Duration(hours: 24);
 
+  /// OS-generated metadata files that tools like macOS Finder and Windows
+  /// Explorer drop into directories. They are never valid git refs.
+  static const _osMetadataFileNames = {'.DS_Store', 'Thumbs.db', 'desktop.ini'};
+
   List<GitReference>? _referencesCache;
 
   GitService(super.context);
@@ -283,8 +287,47 @@ class GitService extends ContextualService {
     return gitCacheDir;
   }
 
-  Future<void> _validateGitCache(Directory directory) {
-    return get<ProcessService>().run(
+  /// Removes OS-generated metadata files from the repository's refs tree so
+  /// that `git fsck` does not treat them as invalid ref names. macOS Finder
+  /// creates `.DS_Store` in any directory it visits; Windows Explorer writes
+  /// `Thumbs.db` and `desktop.ini`. These names are never valid Flutter refs,
+  /// so removing them cannot delete a real branch or tag.
+  ///
+  /// Handles both repository layouts: a bare cache keeps refs at `<repo>/refs`,
+  /// while a non-bare SDK clone keeps them at `<repo>/.git/refs`.
+  Future<void> _purgeOsMetadataFromRefs(Directory repository) async {
+    final refsDirs = [
+      Directory(path.join(repository.path, 'refs')),
+      Directory(path.join(repository.path, '.git', 'refs')),
+    ];
+
+    for (final refsDir in refsDirs) {
+      if (!refsDir.existsSync()) continue;
+
+      await for (final entity
+          in refsDir.list(recursive: true, followLinks: false)) {
+        if (entity is! File) continue;
+        if (!_osMetadataFileNames.contains(path.basename(entity.path))) {
+          continue;
+        }
+        try {
+          entity.deleteSync();
+          logger.debug('Removed OS metadata file: ${entity.path}');
+        } on FileSystemException catch (error) {
+          logger.debug(
+            'Could not remove OS metadata file ${entity.path}: '
+            '${error.message}',
+          );
+        }
+      }
+    }
+  }
+
+  /// Purges OS metadata from the refs tree, then verifies object connectivity
+  /// with `git fsck`. Throws a [ProcessException] if the repository is corrupt.
+  Future<void> _validateGitCache(Directory directory) async {
+    await _purgeOsMetadataFromRefs(directory);
+    await get<ProcessService>().run(
       'git',
       args: ['fsck', '--connectivity-only'],
       workingDirectory: directory.path,
@@ -788,11 +831,7 @@ class GitService extends ContextualService {
 
       _writeAlternateLines(alternatesFile, retainedLines);
 
-      await get<ProcessService>().run(
-        'git',
-        args: ['fsck', '--connectivity-only'],
-        workingDirectory: version.directory,
-      );
+      await _validateGitCache(Directory(version.directory));
 
       logger.info('Dissociated ${version.name} from local git cache.');
 

--- a/test/services/git_service_test.dart
+++ b/test/services/git_service_test.dart
@@ -721,5 +721,135 @@ Future<void> main(List<String> args) async {
         expect(completed, isTrue);
       },
     );
+
+    test(
+      'tolerates OS metadata files in refs and reuses the cache without '
+      'recreating it (issue #1043)',
+      () async {
+        final gitCachePath = p.join(tempDir.path, 'ds_store_cache.git');
+        final context = FvmContext.create(
+          isTest: true,
+          configOverrides: AppConfig(
+            cachePath: p.join(tempDir.path, '.fvm_ds'),
+            gitCachePath: gitCachePath,
+            flutterUrl: remoteDir.path,
+            useGitCache: true,
+          ),
+        );
+
+        final gitService = GitService(context);
+        await gitService.updateLocalMirror();
+        await _expectHeadsTagsOnlyCache(gitCachePath);
+        final refsBefore = await _gitRefs(gitCachePath);
+
+        // A marker at the cache root survives an in-place refresh but is lost
+        // if the cache is recreated via the atomic directory swap. Its survival
+        // proves the cache was reused, not rebuilt from scratch — which is the
+        // actual #1043 regression (forced recreation on every `fvm use`).
+        final reuseMarker = File(p.join(gitCachePath, '.fvm_reuse_marker'))
+          ..writeAsStringSync('reuse');
+
+        // Simulate macOS Finder / Windows Explorer writing metadata into the
+        // refs tree — the exact badRefName fsck failure from issue #1043.
+        final refsDsStore = File(p.join(gitCachePath, 'refs', '.DS_Store'))
+          ..writeAsStringSync('binary junk');
+        final headsDsStore =
+            File(p.join(gitCachePath, 'refs', 'heads', '.DS_Store'))
+              ..writeAsStringSync('binary junk');
+        final headsThumbsDb =
+            File(p.join(gitCachePath, 'refs', 'heads', 'Thumbs.db'))
+              ..writeAsStringSync('junk');
+
+        // Must succeed without recreating the cache.
+        await gitService.updateLocalMirror();
+
+        expect(
+          reuseMarker.existsSync(),
+          isTrue,
+          reason: 'cache must be refreshed in place, not recreated',
+        );
+        expect(refsDsStore.existsSync(), isFalse);
+        expect(headsDsStore.existsSync(), isFalse);
+        expect(headsThumbsDb.existsSync(), isFalse);
+        await _expectHeadsTagsOnlyCache(gitCachePath);
+        expect(await _gitRefs(gitCachePath), unorderedEquals(refsBefore));
+      },
+    );
+
+    test(
+      'still detects genuine object corruption and self-heals the cache',
+      () async {
+        final gitCachePath = p.join(tempDir.path, 'corrupt_cache.git');
+        final context = FvmContext.create(
+          isTest: true,
+          configOverrides: AppConfig(
+            cachePath: p.join(tempDir.path, '.fvm_corrupt'),
+            gitCachePath: gitCachePath,
+            flutterUrl: remoteDir.path,
+            useGitCache: true,
+          ),
+        );
+
+        final gitService = GitService(context);
+        await gitService.updateLocalMirror();
+        await _expectHeadsTagsOnlyCache(gitCachePath);
+
+        // OS metadata the purge SHOULD remove...
+        File(p.join(gitCachePath, 'refs', '.DS_Store'))
+            .writeAsStringSync('binary junk');
+
+        // ...alongside genuine corruption the purge must NOT mask: delete the
+        // loose object backing a reachable ref so fsck truly fails.
+        final headSha = (await runGitCommand(
+          ['rev-parse', 'refs/heads/master'],
+          workingDirectory: gitCachePath,
+        ))
+            .stdout
+            .toString()
+            .trim();
+        final looseObject = File(p.join(
+          gitCachePath,
+          'objects',
+          headSha.substring(0, 2),
+          headSha.substring(2),
+        ));
+        expect(
+          looseObject.existsSync(),
+          isTrue,
+          reason: 'fake remote should produce a loose HEAD object to corrupt',
+        );
+        looseObject.deleteSync();
+
+        // Sanity: the corruption is real — fsck now fails.
+        final corruptFsck = await Process.run(
+          'git',
+          ['fsck', '--connectivity-only'],
+          workingDirectory: gitCachePath,
+          runInShell: true,
+        );
+        expect(
+          corruptFsck.exitCode,
+          isNot(0),
+          reason: 'deleting a reachable object must break fsck',
+        );
+
+        // The real `fvm use` path must recover to a verified-healthy cache,
+        // proving the metadata purge did not suppress real corruption.
+        await gitService.updateLocalMirror();
+
+        final healedFsck = await Process.run(
+          'git',
+          ['fsck', '--connectivity-only'],
+          workingDirectory: gitCachePath,
+          runInShell: true,
+        );
+        expect(
+          healedFsck.exitCode,
+          0,
+          reason: 'cache must self-heal genuine corruption',
+        );
+        await _expectHeadsTagsOnlyCache(gitCachePath);
+      },
+    );
   });
 }

--- a/test/services/git_service_test.dart
+++ b/test/services/git_service_test.dart
@@ -798,27 +798,13 @@ Future<void> main(List<String> args) async {
         File(p.join(gitCachePath, 'refs', '.DS_Store'))
             .writeAsStringSync('binary junk');
 
-        // ...alongside genuine corruption the purge must NOT mask: delete the
-        // loose object backing a reachable ref so fsck truly fails.
-        final headSha = (await runGitCommand(
-          ['rev-parse', 'refs/heads/master'],
-          workingDirectory: gitCachePath,
-        ))
-            .stdout
-            .toString()
-            .trim();
-        final looseObject = File(p.join(
-          gitCachePath,
-          'objects',
-          headSha.substring(0, 2),
-          headSha.substring(2),
-        ));
-        expect(
-          looseObject.existsSync(),
-          isTrue,
-          reason: 'fake remote should produce a loose HEAD object to corrupt',
-        );
-        looseObject.deleteSync();
+        // ...alongside genuine corruption the purge must NOT mask: write a ref
+        // that points at a non-existent object SHA so that
+        // `git fsck --connectivity-only` fails. This is format-agnostic and
+        // does not depend on whether git stored objects loose or in packfiles.
+        const fakeSha = '0000000000000000000000000000000000000001';
+        File(p.join(gitCachePath, 'refs', 'heads', 'corrupt-ref'))
+            .writeAsStringSync('$fakeSha\n');
 
         // Sanity: the corruption is real — fsck now fails.
         final corruptFsck = await Process.run(
@@ -830,7 +816,7 @@ Future<void> main(List<String> args) async {
         expect(
           corruptFsck.exitCode,
           isNot(0),
-          reason: 'deleting a reachable object must break fsck',
+          reason: 'a ref pointing at a non-existent object must break fsck',
         );
 
         // The real `fvm use` path must recover to a verified-healthy cache,


### PR DESCRIPTION
## Problem

On macOS, Finder (and some GUI git clients) write `.DS_Store` into any directory they browse — including FVM's bare git cache at `~/.fvm/cache.git/refs/`. FVM validates the cache with `git fsck --connectivity-only`, which rejects the file as an invalid ref:

```
error: refs/.DS_Store: badRefName: invalid refname format
error: refs/.DS_Store: badRefContent:
```

Because fsck exits non-zero, FVM marks the cache invalid and **recreates it from scratch on every `fvm use`** (#1043) — even though the cache is perfectly healthy (`git for-each-ref` ignores the junk file).

## Fix

`_validateGitCache` now purges OS metadata files (`.DS_Store`, `Thumbs.db`, `desktop.ini`) from the refs tree before running fsck. It handles both repository layouts:

- bare cache → `<repo>/refs`
- non-bare SDK clone → `<repo>/.git/refs`

The SDK-dissociation path's previously-separate fsck now routes through `_validateGitCache`, so every fsck call shares a single purge-then-verify choke-point.

fsck remains strict on genuine object/connectivity corruption, so the existing stale/corrupt-cache detection is unaffected.

## Tests

Two `@git` tests added in `test/services/git_service_test.dart`:

- **Tolerance** — injects `.DS_Store`/`Thumbs.db` into a ready cache's refs, runs `updateLocalMirror()`, and asserts the cache is reused **in place** (a root marker survives) rather than recreated — directly guarding the #1043 regression.
- **Non-regression** — deletes a reachable object so fsck genuinely fails, then asserts the cache self-heals to a state that passes a real `git fsck` — proving the purge does not mask real corruption.

Verified before/after by reverting only the fix: the tolerance test fails with `cache must be refreshed in place, not recreated`, and passes once the fix is applied.

## Verification

- `dart analyze --fatal-infos` — clean
- `dcm analyze lib` — clean
- `dart test -t git` — full real-git suite passes (including SDK dissociation/alternates)

Fixes #1043
