### PR TITLE
chore: prepare v4.1.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 4.1.2
 
 * fix: stop rebuilding the git cache on every command when macOS leaves `.DS_Store` files in it (#1043)
 

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '4.1.1';
+const packageVersion = '4.1.2';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: fvm
 description: A simple cli to manage Flutter SDK versions per project. Support
   channels, releases, and local cache for fast switching between versions.
-version: 4.1.1
+version: 4.1.2
 homepage: https://github.com/leoafarias/fvm
 
 environment:


### PR DESCRIPTION
Prepares the **v4.1.2** patch release.

- Bumps `version` to `4.1.2` in `pubspec.yaml`
- Regenerates `lib/src/version.dart` → `4.1.2`
- Finalizes the CHANGELOG `Unreleased` section as `4.1.2`

## 4.1.2

* fix: stop rebuilding the git cache on every command when macOS leaves `.DS_Store` files in it (#1043)

After this merges, push the `v4.1.2` tag to trigger the release pipeline (pub.dev, GitHub binaries, Homebrew, Chocolatey, Docker).
