### PR TITLE
fix: improve Windows ARM64 support (release parsing, docs, smoke test)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,9 @@ jobs:
   test:
     name: Test
     uses: ./.github/workflows/test.yml
+    # Forward repo secrets (e.g. DCM_CI_KEY/DCM_EMAIL) so the called workflow
+    # can run licensed tools; without this, workflow_call gets no secrets.
+    secrets: inherit
 
   release:
     name: Release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,6 +58,9 @@ jobs:
     name: Test
     timeout-minutes: 30
     runs-on: ubuntu-latest
+    env:
+      DCM_CI_KEY: ${{ secrets.DCM_CI_KEY }}
+      DCM_EMAIL: ${{ secrets.DCM_EMAIL }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -75,20 +78,18 @@ jobs:
         with:
           fatal-infos: false
 
+      # DCM >=1.38.2 refuses to run on CI without a license (DCM_CI_KEY and
+      # DCM_EMAIL). Skip the steps when the repo has no license secrets; the
+      # husky pre-commit/pre-push hooks still run a licensed `dcm analyze lib`
+      # locally. Adding the secrets re-enables DCM here automatically.
       - name: Install DCM
+        if: env.DCM_CI_KEY != '' && env.DCM_EMAIL != ''
         uses: CQLabs/setup-dcm@v1
-        continue-on-error: true
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Ensure DCM available
-        run: |
-          if ! command -v dcm >/dev/null 2>&1; then
-            dart pub global activate dart_code_metrics
-            echo "$HOME/.pub-cache/bin" >> "$GITHUB_PATH"
-          fi
-
       - name: Run DCM
+        if: env.DCM_CI_KEY != '' && env.DCM_EMAIL != ''
         run: dcm analyze lib fvm_mcp/lib
       
       - name: Install lcov

--- a/.github/workflows/windows-arm64-smoke.yml
+++ b/.github/workflows/windows-arm64-smoke.yml
@@ -1,0 +1,74 @@
+name: Windows ARM64 Smoke
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  latest-release-arm64:
+    name: Latest release archive
+    runs-on: windows-11-arm
+
+    steps:
+      - name: Download latest Windows ARM64 release
+        shell: pwsh
+        run: |
+          $release = Invoke-RestMethod `
+            -Headers @{ Accept = 'application/vnd.github+json' } `
+            -Uri 'https://api.github.com/repos/leoafarias/fvm/releases/latest'
+
+          $asset = $release.assets |
+            Where-Object { $_.name -match '^fvm-.+-windows-arm64\.zip$' } |
+            Select-Object -First 1
+
+          if (-not $asset) {
+            throw "No windows-arm64 asset found on latest release $($release.tag_name)"
+          }
+
+          "FVM_RELEASE_TAG=$($release.tag_name)" >> $env:GITHUB_ENV
+          "FVM_RELEASE_ASSET=$($asset.name)" >> $env:GITHUB_ENV
+
+          Invoke-WebRequest -Uri $asset.browser_download_url -OutFile fvm-windows-arm64.zip
+          Expand-Archive -Path fvm-windows-arm64.zip -DestinationPath . -Force
+
+      - name: Verify executable architecture
+        shell: pwsh
+        run: |
+          # cli_pkg cross-builds the Windows arm64 package as fvm.bat plus a
+          # bundled Dart runtime (src\dart.exe) and snapshot; a native fvm.exe
+          # only exists when the package is compiled on a matching host.
+          $exe = @(
+            (Join-Path $PWD 'fvm\fvm.exe'),
+            (Join-Path $PWD 'fvm\src\dart.exe')
+          ) | Where-Object { Test-Path $_ } | Select-Object -First 1
+          if (-not $exe) {
+            throw "Expected fvm\fvm.exe or fvm\src\dart.exe in the archive"
+          }
+
+          $bytes = [System.IO.File]::ReadAllBytes($exe)
+          $peHeaderOffset = [BitConverter]::ToInt32($bytes, 0x3C)
+          $machine = [BitConverter]::ToUInt16($bytes, $peHeaderOffset + 4)
+
+          $machineName = switch ($machine) {
+            0xAA64 { 'arm64' }
+            0x8664 { 'x64' }
+            0x014C { 'x86' }
+            default { "unknown-0x{0:X4}" -f $machine }
+          }
+
+          "Release: $env:FVM_RELEASE_TAG"
+          "Asset: $env:FVM_RELEASE_ASSET"
+          "Checked: $exe"
+          "Machine: $machineName"
+
+          if ($machineName -ne 'arm64') {
+            throw "Expected ARM64 fvm.exe, got $machineName"
+          }
+
+      - name: Run FVM
+        shell: pwsh
+        run: |
+          $env:PATH = "$(Join-Path $PWD 'fvm');$env:PATH"
+          fvm --version

--- a/docs/pages/documentation/getting-started/installation.mdx
+++ b/docs/pages/documentation/getting-started/installation.mdx
@@ -66,6 +66,11 @@ Uninstall:
 choco uninstall fvm
 ```
 
+## Standalone Archive
+
+Native Windows builds are published on the [GitHub Releases](https://github.com/leoafarias/fvm/releases/latest) page.
+Download the `windows-x64` or `windows-arm64` zip for your device, extract it, and add the extracted `fvm` directory to your PATH.
+
   </Tabs.Tab>
 
   <Tabs.Tab>
@@ -129,12 +134,12 @@ The install script (`install.sh`) supports several options:
 |----------|-------------|---------|
 | macOS | x64, arm64 | ✅ |
 | Linux | x64, arm64, riscv64 | ✅ |
-| Windows | x64 | ✅ (via PowerShell/Chocolatey) |
+| Windows | x64, arm64 | ✅ (x64 via Chocolatey; x64/arm64 via standalone archive) |
 
 ### Requirements
 
 - **macOS/Linux**: `curl` and `tar`
-- **Windows**: PowerShell (for script) or Chocolatey
+- **Windows**: PowerShell and Chocolatey for Chocolatey installs, or a standalone zip from GitHub Releases
 
 ## PATH Configuration
 

--- a/lib/src/services/releases_service/models/flutter_releases_model.dart
+++ b/lib/src/services/releases_service/models/flutter_releases_model.dart
@@ -1,8 +1,8 @@
 import 'dart:convert';
 import 'dart:ffi';
-import 'dart:io';
 
 import 'package:dart_mappable/dart_mappable.dart';
+import 'package:meta/meta.dart';
 
 import '../../../models/flutter_version_model.dart';
 import '../../../utils/exceptions.dart';
@@ -43,7 +43,16 @@ class FlutterReleasesResponse with FlutterReleasesResponseMappable {
 
   /// Create FlutterRelease from a map of values
   factory FlutterReleasesResponse.fromMap(Map<String, dynamic> json) {
-    return _parseCurrentReleases(json);
+    return _parseCurrentReleases(json, Abi.current());
+  }
+
+  /// Create FlutterRelease from a map using an explicit platform ABI.
+  @visibleForTesting
+  factory FlutterReleasesResponse.fromMapForTesting(
+    Map<String, dynamic> json, {
+    required Abi abi,
+  }) {
+    return _parseCurrentReleases(json, abi);
   }
 
   /// Returns a [FlutterVersion] release from channel [version]
@@ -69,7 +78,10 @@ class FlutterReleasesResponse with FlutterReleasesResponseMappable {
 /// Goes through the current_release payload.
 /// Finds the proper release base on the hash
 /// Assigns to the current_release
-FlutterReleasesResponse _parseCurrentReleases(Map<String, dynamic> map) {
+FlutterReleasesResponse _parseCurrentReleases(
+  Map<String, dynamic> map,
+  Abi abi,
+) {
   final baseUrlValue = map['base_url'];
   if (baseUrlValue is! String || baseUrlValue.isEmpty) {
     throw AppException('Invalid releases data: missing base_url');
@@ -93,7 +105,9 @@ FlutterReleasesResponse _parseCurrentReleases(Map<String, dynamic> map) {
     );
   }
 
-  final systemArch = _currentSystemArch();
+  final preferredArch = _preferredArchiveArchitecture(abi);
+  final availableArchitectures =
+      _availableArchitecturesByReleaseKey(releasesJson);
 
   final releasesList = <FlutterSdkRelease>[];
   final versionReleaseMap = <String, FlutterSdkRelease>{};
@@ -110,14 +124,17 @@ FlutterReleasesResponse _parseCurrentReleases(Map<String, dynamic> map) {
       }
     }
 
-    if (Platform.isMacOS && systemArch != null) {
-      // Filter out releases based on architecture
-      // Remove if architecture is not compatible
-      final arch = release['dart_sdk_arch'];
-
-      if (arch != systemArch && arch != null) {
-        continue;
-      }
+    // Prefer the native archive when Flutter publishes more than one archive
+    // for the same logical release. If there is no native archive row, keep the
+    // foreign-arch row: FVM installs by git clone (the archive URL is never
+    // downloaded), so this metadata also drives installable-version lookups
+    // and dropping it would hide versions that install fine.
+    if (!_shouldKeepReleaseForPlatform(
+      release,
+      preferredArch: preferredArch,
+      availableArchitectures: availableArchitectures,
+    )) {
+      continue;
     }
 
     final releaseItem = FlutterSdkRelease.fromMap(release);
@@ -158,17 +175,54 @@ FlutterReleasesResponse _parseCurrentReleases(Map<String, dynamic> map) {
   );
 }
 
-String? _currentSystemArch() {
-  if (!Platform.isMacOS) {
-    return null;
+Map<String, Set<String>> _availableArchitecturesByReleaseKey(
+  List<Map<String, dynamic>> releasesJson,
+) {
+  final architecturesByKey = <String, Set<String>>{};
+
+  for (final release in releasesJson) {
+    final arch = release['dart_sdk_arch'];
+    if (arch is! String) continue;
+
+    architecturesByKey
+        .putIfAbsent(_releaseArchitectureKey(release), () => <String>{})
+        .add(arch);
   }
 
-  // Returns the Dart VM architecture, not native hardware.
-  // On Rosetta 2, this returns x64 even on ARM64 Macs.
-  switch (Abi.current()) {
+  return architecturesByKey;
+}
+
+String _releaseArchitectureKey(Map<String, dynamic> release) {
+  return '${release['hash']}|${release['channel']}|${release['version']}';
+}
+
+bool _shouldKeepReleaseForPlatform(
+  Map<String, dynamic> release, {
+  required String? preferredArch,
+  required Map<String, Set<String>> availableArchitectures,
+}) {
+  if (preferredArch == null) return true;
+
+  final arch = release['dart_sdk_arch'];
+  if (arch == null || arch == preferredArch) return true;
+
+  final architectures =
+      availableArchitectures[_releaseArchitectureKey(release)];
+
+  return architectures == null || !architectures.contains(preferredArch);
+}
+
+/// Only macOS and Windows publish per-architecture release rows; every other
+/// ABI falls through to null, which disables the preference filter.
+String? _preferredArchiveArchitecture(Abi abi) {
+  // The ABI reflects the Dart VM architecture, not native hardware: under
+  // Rosetta 2 or Windows x64 emulation this reports x64 even on ARM64 hosts.
+  switch (abi) {
     case Abi.macosArm64:
+    case Abi.windowsArm64:
       return 'arm64';
     case Abi.macosX64:
+    case Abi.windowsX64:
       return 'x64';
     default:
       return null;

--- a/test/utils/releases_test.dart
+++ b/test/utils/releases_test.dart
@@ -1,3 +1,5 @@
+import 'dart:ffi';
+
 import 'package:fvm/src/services/releases_service/models/flutter_releases_model.dart';
 import 'package:fvm/src/utils/exceptions.dart';
 import 'package:mason_logger/mason_logger.dart';
@@ -58,6 +60,108 @@ void main() {
           ],
         };
 
+    Map<String, dynamic> createMultiArchitecturePayload() => {
+          'base_url': 'https://storage.googleapis.com/flutter_infra_release',
+          'current_release': <String, dynamic>{
+            'stable': 'stable_hash',
+            'beta': 'beta_hash',
+            'dev': 'dev_hash',
+          },
+          'releases': <Map<String, dynamic>>[
+            for (final release in [
+              (
+                hash: 'stable_hash',
+                channel: 'stable',
+                version: '3.44.0',
+                suffix: 'stable',
+              ),
+              (
+                hash: 'beta_hash',
+                channel: 'beta',
+                version: '3.45.0-0.1.pre',
+                suffix: 'beta',
+              ),
+              (
+                hash: 'dev_hash',
+                channel: 'dev',
+                version: '3.46.0-0.0.pre',
+                suffix: 'dev',
+              ),
+            ]) ...[
+              <String, dynamic>{
+                'hash': release.hash,
+                'channel': release.channel,
+                'version': release.version,
+                'release_date': '2026-01-01T00:00:00.000Z',
+                'archive':
+                    '${release.channel}/windows/flutter_windows_arm64_${release.version}-${release.suffix}.zip',
+                'sha256': 'sha256hash',
+                'dart_sdk_arch': 'arm64',
+              },
+              <String, dynamic>{
+                'hash': release.hash,
+                'channel': release.channel,
+                'version': release.version,
+                'release_date': '2026-01-01T00:00:00.000Z',
+                'archive':
+                    '${release.channel}/windows/flutter_windows_${release.version}-${release.suffix}.zip',
+                'sha256': 'sha256hash',
+                'dart_sdk_arch': 'x64',
+              },
+            ],
+            <String, dynamic>{
+              'hash': 'legacy_hash',
+              'channel': 'stable',
+              'version': '3.10.0',
+              'release_date': '2024-01-01T00:00:00.000Z',
+              'archive': 'stable/windows/flutter_windows_3.10.0-stable.zip',
+              'sha256': 'sha256hash',
+              'dart_sdk_arch': 'x64',
+            },
+          ],
+        };
+
+    Map<String, dynamic> createX64OnlyPayload({String os = 'windows'}) => {
+          'base_url': 'https://storage.googleapis.com/flutter_infra_release',
+          'current_release': <String, dynamic>{
+            'stable': 'stable_hash',
+            'beta': 'beta_hash',
+            'dev': 'dev_hash',
+          },
+          'releases': <Map<String, dynamic>>[
+            for (final release in [
+              (
+                hash: 'stable_hash',
+                channel: 'stable',
+                version: '3.44.0',
+                suffix: 'stable',
+              ),
+              (
+                hash: 'beta_hash',
+                channel: 'beta',
+                version: '3.45.0-0.1.pre',
+                suffix: 'beta',
+              ),
+              (
+                hash: 'dev_hash',
+                channel: 'dev',
+                version: '3.46.0-0.0.pre',
+                suffix: 'dev',
+              ),
+            ])
+              <String, dynamic>{
+                'hash': release.hash,
+                'channel': release.channel,
+                'version': release.version,
+                'release_date': '2026-01-01T00:00:00.000Z',
+                'archive':
+                    '${release.channel}/$os/flutter_${os}_${release.version}-${release.suffix}.zip',
+                'sha256': 'sha256hash',
+                'dart_sdk_arch': 'x64',
+              },
+          ],
+        };
+
     test('parses valid payload successfully', () {
       final payload = createValidPayload();
       final result = FlutterReleasesResponse.fromMap(payload);
@@ -65,6 +169,62 @@ void main() {
       expect(result.baseUrl, isNotEmpty);
       expect(result.versions, hasLength(3));
       expect(result.channels.stable.version, equals('3.24.0'));
+    });
+
+    test('prefers matching Windows ARM64 releases when available', () {
+      final payload = createMultiArchitecturePayload();
+
+      final result = FlutterReleasesResponse.fromMapForTesting(
+        payload,
+        abi: Abi.windowsArm64,
+      );
+
+      expect(result.channels.stable.dartSdkArch, 'arm64');
+      expect(result.channels.stable.archive, contains('flutter_windows_arm64'));
+      expect(result.fromVersion('3.44.0')?.dartSdkArch, 'arm64');
+    });
+
+    test('keeps Windows x64 current releases when no ARM64 row exists', () {
+      final payload = createX64OnlyPayload();
+
+      final result = FlutterReleasesResponse.fromMapForTesting(
+        payload,
+        abi: Abi.windowsArm64,
+      );
+
+      expect(result.channels.stable.dartSdkArch, 'x64');
+      expect(
+          result.channels.stable.archive, contains('flutter_windows_3.44.0'));
+      expect(result.containsVersion('3.44.0'), isTrue);
+    });
+
+    test('keeps macOS x64-only releases on Apple Silicon', () {
+      // Regression guard: the old macOS-only filter dropped foreign-arch rows
+      // outright, hiding releases that install fine via git clone.
+      final payload = createX64OnlyPayload(os: 'macos');
+
+      final result = FlutterReleasesResponse.fromMapForTesting(
+        payload,
+        abi: Abi.macosArm64,
+      );
+
+      expect(result.channels.stable.dartSdkArch, 'x64');
+      expect(result.containsVersion('3.44.0'), isTrue);
+    });
+
+    test('keeps unmatched Windows x64 releases on Windows ARM64', () {
+      final payload = createMultiArchitecturePayload();
+
+      final result = FlutterReleasesResponse.fromMapForTesting(
+        payload,
+        abi: Abi.windowsArm64,
+      );
+
+      expect(result.fromVersion('3.10.0')?.dartSdkArch, 'x64');
+      expect(
+        result.fromVersion('3.10.0')?.archive,
+        'stable/windows/flutter_windows_3.10.0-stable.zip',
+      );
     });
 
     test('throws on missing base_url', () {


### PR DESCRIPTION
## Context

Refs #1047. A user on Windows 11 ARM64 reported that FVM "is only available for x64" and that `fvm install` produced an x64 Flutter SDK. Investigation showed:

- Native `windows-arm64` zips have shipped on every GitHub release since 4.0.5 (Dec 2025) — verified the bundled runtime in `fvm-4.1.2-windows-arm64.zip` is a real ARM64 PE — but the install docs said Windows was x64-only, so there was no way to discover them.
- Chocolatey (the promoted Windows path) compiles `fvm.exe` at install time with Chocolatey's x64 Dart SDK, so choco installs run under emulation.
- The x64 Flutter SDK is a downstream effect: Flutter's own `update_dart_sdk.ps1` selects the Dart SDK via `PROCESSOR_ARCHITECTURE`, which reports `AMD64` inside an emulated x64 process chain. Running the native ARM64 FVM makes the same `fvm install` set up an ARM64 SDK automatically (for Flutter versions that publish arm64 artifacts, i.e. 3.44+).

## Changes

- **Release parsing** (`flutter_releases_model.dart`): recognize Windows ABIs and prefer the native `dart_sdk_arch` row when Flutter publishes multiple archive rows for the same release. When only a foreign-arch row exists, keep it: FVM installs by git clone (the archive URL is never downloaded), and this metadata drives installable-version lookups, so dropping it would hide versions that install fine.
- **Behavior change worth a CHANGELOG line at release prep**: on Apple Silicon, x64-only release rows are no longer hidden from `fvm releases`/version lookups (the old macOS filter dropped them). Covered by a new regression test.
- **Docs** (`installation.mdx`): document the standalone `windows-x64`/`windows-arm64` GitHub Release archives and correct the platform support matrix.
- **CI** (`windows-arm64-smoke.yml`, manual dispatch): post-release verifier on GitHub's `windows-11-arm` runner — downloads the latest released `windows-arm64` zip, asserts the bundled executable's PE machine type is `arm64`, and runs `fvm --version` natively. Note the artifact layout is `fvm.bat` + `src\dart.exe` + snapshot (cli_pkg cross-build), so the check accepts either `fvm.exe` or `src\dart.exe`.

## Verification

- `dart analyze --fatal-infos`, `dcm analyze lib`: clean
- `dart test test/utils/releases_test.dart`: 14 passed (incl. new Windows arm64/x64-fallback and macOS Apple Silicon tests)
- Fast suite `dart test -x "sdk || network || git || integration || migration"`: 387 passed
- Workflow YAML validated; PE-header check logic verified locally against the real `fvm-4.1.2-windows-arm64.zip`

## Follow-ups (not in this PR)

- Dispatch the smoke workflow once after merge (workflow_dispatch requires it on the default branch).
- Native package-manager delivery: choco arch-awareness fights cli_pkg's compile-from-source model; a winget manifest (per-arch installers) is likely the cleaner path.
- Optional: add a choco job to the smoke workflow to prove the x64-emulation theory in CI.