### PR TITLE
Update .gitignore entry for FVM directory

### DIFF
--- a/docs/pages/documentation/guides/quick-reference.md
+++ b/docs/pages/documentation/guides/quick-reference.md
@@ -81,7 +81,7 @@ myproject/
 ## Tips
 
 - Use `fvm doctor` to troubleshoot issues
-- Add `.fvm/flutter_sdk` to `.gitignore`
+- Add `.fvm/` to `.gitignore`
 - Commit `.fvmrc` for team consistency
 - Use `--no-setup` for faster caching
 - Enable git cache for faster installs


### PR DESCRIPTION
If I remove the .fvm folder and run `fvm use` in the root project folder it sets .fvm/ in .gitignore.