### PR TITLE
fix: add arm64 platform support to docker image builds

### DIFF
--- a/.github/workflows/deploy_docker.yml
+++ b/.github/workflows/deploy_docker.yml
@@ -31,6 +31,7 @@ jobs:
             uses: docker/build-push-action@v5
             with:
               file: ./.docker/Dockerfile
+              platforms: linux/amd64,linux/arm64/v8
               push: true
               tags: leoafarias/fvm:latest
     

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,6 +164,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           file: ./.docker/Dockerfile
+          platforms: linux/amd64,linux/arm64/v8
           push: true
           tags: leoafarias/fvm:${{ env.MODIFIED_TAG_NAME }}
           build-args: |


### PR DESCRIPTION
Enables linux/arm64/v8 alongside linux/amd64 in both docker build-push steps so fvm's Docker image runs natively on arm64 hosts (Ampere, Apple Silicon, etc). Realigns conceptadev/fvm#845 on top of current main.

Fixes #762