### PR TITLE
docs: add Android Studio SDK setup guide

### DIFF
--- a/docs/pages/documentation/getting-started/configuration.mdx
+++ b/docs/pages/documentation/getting-started/configuration.mdx
@@ -62,7 +62,7 @@ Inside the directory, you will find the following files and symlinks:
 -  **version** - (internal use only) File containing the version of FVM that created this configuration.
 
 <Callout type="tip">
-  Need IDE-specific steps? Follow the [Android Studio and IntelliJ workflow guide](/documentation/guides/workflows#android-studio--intellij) to point the IDE at the project's `.fvm/flutter_sdk` symlink and refresh caches after switching versions.
+  Need IDE-specific steps? Follow the [Android Studio and IntelliJ guide](/documentation/guides/android-studio) to configure either a project SDK or the FVM global SDK and refresh the IDE after switching versions.
 </Callout>
 
 <Callout type="warning">

--- a/docs/pages/documentation/getting-started/faq.md
+++ b/docs/pages/documentation/getting-started/faq.md
@@ -21,6 +21,14 @@ If `fvm flutter` or `fvm dart` commands are not working:
 
 ---
 
+## Android Studio cannot find Flutter after `fvm global`
+
+`fvm global` creates an FVM-managed `default` SDK link, but it does not change Android Studio or IntelliJ settings. In **Settings → Languages & Frameworks → Flutter**, select `$HOME/fvm/default` on macOS/Linux or `C:\Users\<user>\fvm\default` on Windows. If you configured a custom cache, select `<FVM_CACHE_PATH>/default` instead.
+
+The IDE can resolve this link to a specific cached version. After changing the global version, verify the version shown in the IDE and reselect the FVM path if necessary. See the [Android Studio and IntelliJ guide](../guides/android-studio) for project-specific setup and troubleshooting.
+
+---
+
 ## How does FVM find the Flutter version to use?
 
 FVM searches for the Flutter SDK in this order:

--- a/docs/pages/documentation/guides/_meta.json
+++ b/docs/pages/documentation/guides/_meta.json
@@ -23,7 +23,9 @@
   "global-configuration": {
     "title": "Global Configuration"
   },
-
+  "android-studio": {
+    "title": "Android Studio / IntelliJ"
+  },
   "vscode": {
     "title": "VSCode Configuration"
   },

--- a/docs/pages/documentation/guides/android-studio.mdx
+++ b/docs/pages/documentation/guides/android-studio.mdx
@@ -46,7 +46,14 @@ If `.fvm/flutter_sdk` is missing, run `fvm use <version>` again from the project
 
 FVM automatically retargets `.fvm/flutter_sdk` when you run `fvm use`. Android Studio only follows that change when its project metadata preserves the symlink path instead of the resolved cache path.
 
-Run this command from the project root:
+The most reliable check is in Android Studio itself:
+
+1. Open **Settings → Languages & Frameworks → Flutter** and note the displayed SDK path and version.
+2. Run `fvm use <different-version>` from the project root.
+3. Reopen the Flutter settings without reselecting the SDK.
+4. If the displayed version changed, the IDE followed the FVM link. If it still shows the previous version or a path under `<FVM cache>/versions/<version>`, reselect the SDK manually.
+
+You can also inspect the saved project metadata with:
 
 ```bash
 fvm doctor
@@ -54,10 +61,14 @@ fvm doctor
 
 Check the **IntelliJ → SDK Path** result:
 
-- **SDK Path points to project directory**: the saved path contains `.fvm/flutter_sdk`, so the IDE can follow future `fvm use` changes.
+- **SDK Path points to project directory**: the saved metadata contains `.fvm/flutter_sdk`; confirm automatic switching with the Android Studio check above.
 - **SDK Path does not point to the project directory**: the IDE saved a concrete path such as `<FVM cache>/versions/<version>`, so it will not switch automatically.
 
 You can also inspect `.idea/libraries/Dart_SDK.xml`. Its SDK entries should contain `$PROJECT_DIR$/.fvm/flutter_sdk`; a direct cache-version path means the symlink was resolved.
+
+<Callout type="info">
+  `fvm doctor` checks the IDE metadata on disk. It does not execute Android Studio or prove that the running IDE refreshed after a version switch.
+</Callout>
 
 ## Configure the global SDK
 
@@ -87,7 +98,7 @@ After changing `PATH`, close and reopen Android Studio or IntelliJ. Run `command
   Some Android Studio and IntelliJ versions resolve an SDK symlink to its current cached version when saving the setting. After `fvm use` or `fvm global` switches versions, verify the version shown in the IDE and reselect the FVM SDK path if it is stale. This is tracked by [flutter-intellij#6616](https://github.com/flutter/flutter-intellij/issues/6616).
 </Callout>
 
-Typing or pasting the exact FVM path into the SDK field instead of selecting it with the folder browser can preserve the symlink in some IDE versions. Do not add a trailing slash, select **Apply**, and verify the result with `fvm doctor`. This is a best-effort workaround; if the IDE still resolves the path, reselect the FVM SDK after each version change.
+Typing or pasting the exact FVM path into the SDK field instead of selecting it with the folder browser can preserve the symlink in some IDE versions. Do not add a trailing slash, then select **Apply**. Check the path and version shown in Android Studio and use `fvm doctor` to inspect the saved metadata. This is a best-effort workaround; if the field changes to a concrete cache-version path, reselect the FVM SDK after each version change.
 
 ## Troubleshooting
 

--- a/docs/pages/documentation/guides/android-studio.mdx
+++ b/docs/pages/documentation/guides/android-studio.mdx
@@ -1,0 +1,117 @@
+---
+id: android_studio
+title: Android Studio and IntelliJ
+---
+
+import { Callout } from "nextra/components";
+
+# Android Studio and IntelliJ
+
+FVM manages Flutter SDK installations and links, but it does not change Android Studio or IntelliJ settings. The IDE can also remember a previously configured SDK or discover one from `PATH`, so it might use a different Flutter installation than FVM.
+
+Make sure the IDE's [Flutter plugin](https://docs.flutter.dev/tools/android-studio#install-the-flutter-plugin) is installed before configuring an SDK.
+
+## Choose the SDK path
+
+| Use case | Flutter SDK root |
+| --- | --- |
+| Project pinned with `fvm use` | `/path/to/project/.fvm/flutter_sdk` |
+| Global version with the default cache | `$HOME/fvm/default` on macOS/Linux or `C:\Users\<user>\fvm\default` on Windows |
+| Global version with a custom cache | `<FVM_CACHE_PATH>/default` |
+
+Use the SDK root shown above, not its `bin` directory.
+
+<Callout type="tip">
+  Prefer the project SDK for application development. It keeps Android Studio aligned with the version recorded in the project's `.fvmrc` file.
+</Callout>
+
+## Configure a project SDK
+
+From the project root, select and install its Flutter version:
+
+```bash
+fvm use <version>
+```
+
+Then configure the IDE:
+
+1. Open **File → Settings** on Windows/Linux, or **Android Studio/IntelliJ → Settings** on macOS.
+2. Select **Languages & Frameworks → Flutter**.
+3. Set **Flutter SDK path** to the absolute project path ending in `.fvm/flutter_sdk`.
+4. Select **Apply**, then verify that the displayed Flutter version matches `fvm flutter --version`.
+
+If `.fvm/flutter_sdk` is missing, run `fvm use <version>` again from the project root.
+
+### Check automatic SDK switching
+
+FVM automatically retargets `.fvm/flutter_sdk` when you run `fvm use`. Android Studio only follows that change when its project metadata preserves the symlink path instead of the resolved cache path.
+
+Run this command from the project root:
+
+```bash
+fvm doctor
+```
+
+Check the **IntelliJ → SDK Path** result:
+
+- **SDK Path points to project directory**: the saved path contains `.fvm/flutter_sdk`, so the IDE can follow future `fvm use` changes.
+- **SDK Path does not point to the project directory**: the IDE saved a concrete path such as `<FVM cache>/versions/<version>`, so it will not switch automatically.
+
+You can also inspect `.idea/libraries/Dart_SDK.xml`. Its SDK entries should contain `$PROJECT_DIR$/.fvm/flutter_sdk`; a direct cache-version path means the symlink was resolved.
+
+## Configure the global SDK
+
+Use a global SDK for projects that don't pin a version with FVM:
+
+```bash
+fvm global stable
+```
+
+In the IDE's Flutter settings, select the applicable global SDK root:
+
+- macOS/Linux default: `$HOME/fvm/default`
+- Windows default: `C:\Users\<user>\fvm\default`
+- Custom cache: `<configured-cache-path>/default`
+
+These paths use placeholders for readability. Enter the actual absolute path in the IDE—for example, `/Users/alice/fvm/default` or `C:\Users\alice\fvm\default`—instead of relying on environment-variable expansion.
+
+For command-line and IDE discovery, put the global SDK's `bin` directory before any other Flutter installation on `PATH`. For example, on macOS or Linux:
+
+```bash
+export PATH="$HOME/fvm/default/bin:$PATH"
+```
+
+After changing `PATH`, close and reopen Android Studio or IntelliJ. Run `command -v flutter` on macOS/Linux or `where flutter` on Windows to check which installation appears first.
+
+<Callout type="warning">
+  Some Android Studio and IntelliJ versions resolve an SDK symlink to its current cached version when saving the setting. After `fvm use` or `fvm global` switches versions, verify the version shown in the IDE and reselect the FVM SDK path if it is stale. This is tracked by [flutter-intellij#6616](https://github.com/flutter/flutter-intellij/issues/6616).
+</Callout>
+
+Typing or pasting the exact FVM path into the SDK field instead of selecting it with the folder browser can preserve the symlink in some IDE versions. Do not add a trailing slash, select **Apply**, and verify the result with `fvm doctor`. This is a best-effort workaround; if the IDE still resolves the path, reselect the FVM SDK after each version change.
+
+## Troubleshooting
+
+### Could not find a Flutter SDK
+
+1. Run `fvm use <version>` for a project SDK or `fvm global <version>` for a global SDK.
+2. Confirm that `.fvm/flutter_sdk` or the global `default` link exists.
+3. Select that SDK root under **Settings → Languages & Frameworks → Flutter**. Do not select its `bin` directory.
+4. Restart the IDE if it still shows the prompt.
+
+### The IDE uses the wrong Flutter version
+
+1. Compare the IDE's displayed version with `fvm flutter --version` for a pinned project.
+2. Check `command -v flutter` on macOS/Linux or `where flutter` on Windows for another Flutter installation earlier on `PATH`.
+3. Run `fvm doctor` and check whether the saved IntelliJ SDK path still contains `.fvm/flutter_sdk`.
+4. Reopen the Flutter settings and reselect the FVM path after switching versions.
+5. For Android projects, run **Sync Project with Gradle Files** after the SDK change. Use **Find Action** and search for that command if it is not visible in the menu.
+
+### Flutter works, but the Android toolchain does not
+
+The Flutter SDK and Android SDK are separate. Run:
+
+```bash
+fvm flutter doctor
+```
+
+Use Android Studio's **Tools → SDK Manager** to install any missing Android SDK components, then follow the reported license or toolchain steps. See Flutter's [installation troubleshooting guide](https://docs.flutter.dev/install/troubleshoot#android-setup) for Android-specific errors.

--- a/docs/pages/documentation/guides/global-configuration.mdx
+++ b/docs/pages/documentation/guides/global-configuration.mdx
@@ -24,6 +24,14 @@ To accomplish this, FVM provides you with a helper command to configure a global
 fvm global {version}
 ```
 
+FVM creates a `default` link inside the configured cache:
+
+- macOS/Linux default: `$HOME/fvm/default`
+- Windows default: `C:\Users\<user>\fvm\default`
+- Custom cache: `<FVM_CACHE_PATH>/default`
+
+Add the link's `bin` directory before other Flutter installations on `PATH`. If you use Android Studio or IntelliJ, also follow the [IDE configuration guide](/documentation/guides/android-studio#configure-the-global-sdk); FVM does not change the IDE's SDK setting.
+
 Now you will be able to do the following.
 
 ```bash title="Example"
@@ -44,4 +52,10 @@ flutter --version # Will be stable release
   After you run the command, FVM will check if the global version is configured
   in your environment path. If it is not, it will provide you with the path that
   needs to be configured.
+</Callout>
+
+<Callout type="warning">
+  Android Studio and IntelliJ can resolve the `default` link to a specific cached
+  version. After changing the global version, verify the version shown in the IDE
+  and reselect the FVM path if necessary.
 </Callout>

--- a/docs/pages/documentation/guides/workflows.mdx
+++ b/docs/pages/documentation/guides/workflows.mdx
@@ -108,7 +108,7 @@ Configure a system-wide default Flutter version.
 fvm global 3.19.0
 
 # Add to PATH (one-time setup)
-export PATH="$PATH:$HOME/fvm/default/bin"
+export PATH="$HOME/fvm/default/bin:$PATH"
 
 # Use global version
 flutter doctor
@@ -194,32 +194,9 @@ FVM automatically configures VS Code settings. To manually configure:
 
 ### Android Studio / IntelliJ
 
-FVM keeps a project-scoped symlink at `.fvm/flutter_sdk`. Running `fvm use <version>` updates this symlink to point to the selected Flutter SDK version.
+FVM does not change Android Studio or IntelliJ settings automatically. Configure the IDE with the project link at `.fvm/flutter_sdk` or the global link at `<FVM cache>/default`.
 
-> **Known limitation:** Android Studio and IntelliJ resolve symlinks to their absolute target path when saving settings ([flutter-intellij#6616](https://github.com/flutter/flutter-intellij/issues/6616)). This means the IDE stores the resolved path (e.g., `~/.fvm/versions/3.19.0`) rather than the symlink itself. After running `fvm use` to switch versions, you may need to re-select the SDK path in settings for the IDE to pick up the new version.
-
-**Point the IDE at FVM**
-- Open **File → Settings** (Windows/Linux) or **Android Studio → Preferences** (macOS).
-- Navigate to **Languages & Frameworks → Flutter**.
-- Set **Flutter SDK path** to the absolute path of `.fvm/flutter_sdk` in your project (e.g., `/path/to/project/.fvm/flutter_sdk`).
-- **Tip:** Paste the path directly into the text field instead of using the file browser—this may help preserve the symlink path in some IDE versions.
-- Click **Apply**. Restart the IDE if prompted.
-
-**After switching Flutter versions**
-- Run `fvm use <version>` in the project so `.fvm/flutter_sdk` points at the new cached SDK.
-- Re-open **Settings → Languages & Frameworks → Flutter** and re-select the `.fvm/flutter_sdk` path so the IDE resolves to the new target.
-- For Android projects: **File → Sync Project with Gradle Files** to refresh Gradle metadata. If this option isn't visible, press `Ctrl+Shift+A` (or `Cmd+Shift+A` on macOS) and search for "Sync Project with Gradle Files".
-- If Dart Analysis shows stale errors, open **View → Tool Windows → Dart Analysis** and click the restart icon in the toolbar.
-- Run `fvm doctor` to verify the IDE configuration is correct.
-
-**Troubleshooting stale paths**
-- Use **File → Invalidate Caches / Restart…** to clear cached SDK paths.
-- Confirm the symlink exists with `ls -l .fvm/flutter_sdk`. If missing, run `fvm use` to recreate it.
-
-**Multi-module or monorepo setups**
-- Each module should run `fvm use` within its directory so `.fvm/flutter_sdk` resolves locally.
-- Android Studio allows multiple Flutter SDK entries—ensure every module references its own `.fvm/flutter_sdk` rather than a shared global install.
-- When switching versions in one module, repeat the Gradle/Flutter sync steps within that module’s window.
+JetBrains IDEs can resolve either link to its current cached version, so verify and reselect the SDK after switching versions. See the [Android Studio and IntelliJ guide](/documentation/guides/android-studio) for the complete setup and troubleshooting steps.
 
 ## Best practices
 


### PR DESCRIPTION
## Summary
- add a dedicated Android Studio and IntelliJ guide for project-pinned and global FVM SDK paths
- explain JetBrains symlink resolution, distinguish Android Studio verification from the `fvm doctor` metadata check, and document the manual fallback when the IDE stays on an old SDK
- link the guide from global configuration, project configuration, common workflows, and the FAQ

Related to #697, #724, and #767.

## Validation
- `cd docs && yarn build` — passed; generated 23 static pages, including `/documentation/guides/android-studio`
- `git diff --check origin/main...HEAD` — passed
- Android Studio Quail 2 (2026.1.2), Flutter plugin 95.0.0 — the SDK field resolved `.fvm/flutter_sdk` to Flutter 3.41.2; after `fvm use 3.44.6`, the link changed to 3.44.6 while the IDE metadata remained on 3.41.2
- Vercel preview deployment — passed
- browser verification at 1440×900 and 390×844 — navigation, internal links, headings, and paths rendered correctly with no page overflow or console errors
